### PR TITLE
fix(AnthropicHandler): add Authorization header to resolve Minimax errors

### DIFF
--- a/src/utils/anthropicHandler.ts
+++ b/src/utils/anthropicHandler.ts
@@ -56,6 +56,7 @@ export class AnthropicHandler {
         const client = new Anthropic({
             apiKey: currentApiKey,
             baseURL: baseUrl,
+            authToken: currentApiKey, // 解决 Minimax 报错： Please carry the API secret key in the 'Authorization' field of the request header
             defaultHeaders: defaultHeaders
         });
 


### PR DESCRIPTION
在我这边，不加这一行时会出现以下报错：
<img width="640" height="986" alt="截图 2025-11-30 17-08-53" src="https://github.com/user-attachments/assets/198a4bbd-ca9f-4da4-8ea9-e65f08dd7773" />

加了之后就没有报错可以正常使用minimax服务了