### PR TITLE
fix: use correct CacheControl MIME type during Anthropic conversion

### DIFF
--- a/src/utils/anthropicConverter.ts
+++ b/src/utils/anthropicConverter.ts
@@ -24,7 +24,7 @@ import { Logger } from './logger';
 
 // 自定义数据部分MIME类型
 const CustomDataPartMimeTypes = {
-    CacheControl: 'application/vnd.vscode.copilot.cache-control'
+    CacheControl: 'cache_control'
 } as const;
 
 // 辅助函数 - 过滤undefined值


### PR DESCRIPTION
The MIME type defined in [microsoft/vscode-copilot-chat](https://github.com/microsoft/vscode-copilot-chat/blob/fef24f4536baa1e200b3170b5a1cbad7b29d6c08/src/platform/endpoint/common/endpointTypes.ts) should be used during request conversion to Anthropic SDK.

Fixes #33.