### PR TITLE
增加cache_control数量限制可配置项

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,14 @@
                     "description": "控制AI模型输出的最大token数量。较大的值允许更长的响应。",
                     "scope": "application"
                 },
+                "gcmp.anthropicCacheLimit": {
+                    "type": "number",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Anthropic API 请求中 cache_control 断点的最大数量，若遇到 cache_control 超限错误可适当降低此值。设为 0 则不限制。",
+                    "scope": "application"
+                },
                 "gcmp.editToolMode": {
                     "type": "string",
                     "enum": [

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -69,6 +69,8 @@ export interface CommitConfig {
 export interface GCMPConfig {
     /** 最大输出token数量 */
     maxTokens: number;
+    /** Anthropic cache_control 断点额外上限 */
+    anthropicCacheLimit: number;
     /** 智谱AI配置 */
     zhipu: ZhipuConfig;
     /** MiniMax配置 */
@@ -127,6 +129,7 @@ export class ConfigManager {
 
         this.cache = {
             maxTokens: this.validateMaxTokens(config.get<number>('maxTokens', 256000)),
+            anthropicCacheLimit: config.get<number>('anthropicCacheLimit', 4),
             zhipu: {
                 search: {
                     enableMCP: config.get<boolean>('zhipu.search.enableMCP', true) // 默认启用MCP模式（Coding Plan专属）


### PR DESCRIPTION
有的中转站会自己添加 cache_control breakpoint，导致插件出现 `A maximum of 4 blocks with cache_control may be provided. Found 5` 错误。

增加一个可选的 cache_control 数量限制配置项，预先削减 cache_control breakpoint 数量。

https://github.com/VicBilibily/GCMP/issues/81