### PR TITLE
feat: MiniMax Coding Plan 图片桥接功能

### DIFF
--- a/src/providers/config/minimax.json
+++ b/src/providers/config/minimax.json
@@ -16,7 +16,7 @@
             "maxOutputTokens": 128000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {
@@ -31,7 +31,7 @@
             "maxOutputTokens": 128000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {
@@ -46,7 +46,7 @@
             "maxOutputTokens": 128000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {
@@ -61,7 +61,7 @@
             "maxOutputTokens": 128000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {
@@ -76,7 +76,7 @@
             "maxOutputTokens": 64000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {
@@ -91,7 +91,7 @@
             "maxOutputTokens": 64000,
             "capabilities": {
                 "toolCalling": true,
-                "imageInput": false
+                "imageInput": true
             }
         },
         {

--- a/src/providers/minimaxProvider.ts
+++ b/src/providers/minimaxProvider.ts
@@ -129,7 +129,6 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
      * 注意：只处理当前轮次的新消息（最后一条用户消息），历史消息已在上一轮处理过
      * @param messages 原始消息列表
      * @param modelConfig 模型配置
-     * @param progress 可选的进度报告器，用于显示图片解析进度
      * @returns 处理后的消息列表
      */
     private async preprocessImagesInMessages(

--- a/src/providers/minimaxProvider.ts
+++ b/src/providers/minimaxProvider.ts
@@ -118,8 +118,9 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
      * MiniMax Vision API 仅支持 JPEG、PNG、WebP，不支持 GIF
      */
     private isImageMimeType(mimeType: string): boolean {
+        const normalizedMimeType = mimeType.toLowerCase() === 'image/jpg' ? 'image/jpeg' : mimeType.toLowerCase();
         const supportedTypes = ['image/jpeg', 'image/png', 'image/webp'];
-        return supportedTypes.includes(mimeType.toLowerCase());
+        return supportedTypes.includes(normalizedMimeType);
     }
 
     /**

--- a/src/providers/minimaxProvider.ts
+++ b/src/providers/minimaxProvider.ts
@@ -18,6 +18,7 @@ import { ProviderConfig, ModelConfig } from '../types/sharedTypes';
 import { Logger, ApiKeyManager, MiniMaxWizard } from '../utils';
 import { StatusBarManager } from '../status';
 import { TokenUsagesManager } from '../usages/usagesManager';
+import { MiniMaxVisionTool } from '../tools/minimaxVision';
 
 /**
  * MiniMax 专用模型提供商类
@@ -110,6 +111,132 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
         }
         // 否则使用提供商默认的 provider key
         return this.providerKey;
+    }
+
+    /**
+     * 检查是否为支持的图片 MIME 类型
+     * MiniMax Vision API 仅支持 JPEG、PNG、WebP，不支持 GIF
+     */
+    private isImageMimeType(mimeType: string): boolean {
+        const supportedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+        return supportedTypes.includes(mimeType.toLowerCase());
+    }
+
+    /**
+     * 预处理消息中的图片（图片桥接功能）
+     * 使用 MiniMax Vision API 将图片转换为文字描述后再发送给模型
+     * 注意：只处理当前轮次的新消息（最后一条用户消息），历史消息已在上一轮处理过
+     * @param messages 原始消息列表
+     * @param modelConfig 模型配置
+     * @param progress 可选的进度报告器，用于显示图片解析进度
+     * @returns 处理后的消息列表
+     */
+    private async preprocessImagesInMessages(
+        messages: Array<LanguageModelChatMessage>,
+        modelConfig: ModelConfig
+    ): Promise<Array<LanguageModelChatMessage>> {
+        // 只对 Coding Plan 模型启用图片桥接
+        const providerKey = this.getProviderKeyForModel(modelConfig);
+        if (providerKey !== 'minimax-coding') {
+            return messages;
+        }
+
+        // 检查是否有 MiniMax Vision API 密钥
+        const hasApiKey = await ApiKeyManager.hasValidApiKey('minimax-coding');
+        if (!hasApiKey) {
+            Logger.debug('MiniMax 图片桥接: 未配置 Coding Plan API 密钥，跳过图片预处理');
+            return messages;
+        }
+
+        const visionTool = new MiniMaxVisionTool();
+
+        // 找到最后一条用户消息（当前轮次的新消息）
+        let lastUserMessageIndex = -1;
+        for (let i = messages.length - 1; i >= 0; i--) {
+            if (messages[i].role === vscode.LanguageModelChatMessageRole.User) {
+                lastUserMessageIndex = i;
+                break;
+            }
+        }
+
+        // 统计需要处理的图片数量（包含所有 image/* 类型，确保 GIF 等不支持格式也进入桥接）
+        let totalImages = 0;
+        let processedCount = 0;
+        if (lastUserMessageIndex >= 0) {
+            const lastUserMessage = messages[lastUserMessageIndex];
+            for (const part of lastUserMessage.content) {
+                if (part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/')) {
+                    totalImages++;
+                }
+            }
+        }
+
+        if (totalImages === 0) {
+            return messages;
+        }
+
+        Logger.info(`检测到 ${totalImages} 张图片需要分析`);
+
+        // 只处理最后一条用户消息
+        const lastUserMessage = messages[lastUserMessageIndex];
+
+        // 先提取用户原始问题（用于喂给视觉模型的提示词）
+        const originalTextParts: string[] = [];
+        for (const part of lastUserMessage.content) {
+            if (part instanceof vscode.LanguageModelTextPart) {
+                originalTextParts.push(part.value);
+            }
+        }
+        const originalQuestion = originalTextParts.join('\n').trim();
+
+        // 再处理图片部分
+        const imageDescriptions: string[] = [];
+        for (const part of lastUserMessage.content) {
+            if (part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/')) {
+                if (!this.isImageMimeType(part.mimeType)) {
+                    Logger.error(`不支持的图片格式: ${part.mimeType}`);
+                    throw new Error(`不支持的图片格式: ${part.mimeType}。MiniMax Vision 仅支持 JPEG、PNG、WebP。`);
+                } else {
+                    processedCount++;
+                    try {
+                        Logger.info(`正在分析图片 (${processedCount}/${totalImages}): mimeType=${part.mimeType}, data大小=${part.data.length}字节`);
+
+                        // 带上图片序号（共N张）和用户问题，让视觉模型给出结构化、有针对性的描述
+                        const visionPrompt = originalQuestion
+                            ? `这是第${processedCount}张（共${totalImages}张）。用户的问题是：${originalQuestion}\n\n请详细描述这张图片的内容，力求准确完整。`
+                            : `这是第${processedCount}张（共${totalImages}张）。\n\n请详细描述这张图片的内容，力求准确完整。`;
+                        const response = await visionTool.understandImage(part.data, part.mimeType, visionPrompt);
+                        imageDescriptions.push(response.content);
+                        Logger.info(`图片 ${processedCount}/${totalImages} 转换成功`);
+                    } catch (error) {
+                        Logger.error(`图片 ${processedCount}/${totalImages} 转换失败`, error instanceof Error ? error : undefined);
+                        imageDescriptions.push('[图片分析失败]');
+                    }
+                }
+            }
+        }
+
+        if (processedCount > 0) {
+            Logger.info(`全部 ${processedCount} 张图片解析完成`);
+        }
+
+        // 构造新的 content 数组：用 Vision 描述替换图片 parts，保留原始文本 parts
+        // 格式：先列出"你（主模型）不支持图片"，再逐张列出 Vision 描述，最后附用户问题
+        const bridgedContent: vscode.LanguageModelTextPart[] = [
+            new vscode.LanguageModelTextPart(
+                `你（主模型）不支持直接接收图片，用户共上传了${processedCount}张图片。以下是由视觉模型对这些图片的分析结果，以及用户的原始问题。\n\n图片内容（共${processedCount}张）：\n`
+            )
+        ];
+        for (let i = 0; i < imageDescriptions.length; i++) {
+            bridgedContent.push(new vscode.LanguageModelTextPart(`${i + 1}. ${imageDescriptions[i]}\n`));
+        }
+        bridgedContent.push(new vscode.LanguageModelTextPart(`\n用户问题：${originalQuestion}`));
+
+        // 直接修改原消息的内容，不创建新数组
+        // 使用类型断言因为 LanguageModelChatMessage 的 content 是只读的
+        (lastUserMessage as unknown as { content: typeof bridgedContent }).content = bridgedContent;
+
+        return messages;
     }
 
     /**
@@ -243,8 +370,18 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
             `${this.providerConfig.displayName}: 即将处理请求，使用 ${providerKey === 'minimax-coding' ? 'Coding Plan' : '普通'} 密钥 - 模型: ${modelConfig.name}`
         );
 
-        // 计算输入 token 数量并更新状态栏
-        const totalInputTokens = await this.updateContextUsageStatusBar(model, messages, modelConfig, options);
+        // 图片桥接：预处理消息中的图片
+        // 当模型不支持图片输入但使用 Coding Plan 密钥时，自动将图片转换为文字描述
+        // 注意：此操作在 Token 统计之前执行，确保统计的是模型实际收到的文本描述而非原始图片
+        const processedMessages = await this.preprocessImagesInMessages(messages, modelConfig);
+
+        // 计算输入 token 数量并更新状态栏（使用桥接后的消息，图片已被替换为文本描述）
+        const totalInputTokens = await this.updateContextUsageStatusBar(
+            model,
+            processedMessages,
+            modelConfig,
+            options
+        );
 
         // === Token 统计: 记录预估输入 token ===
         const usagesManager = TokenUsagesManager.instance;
@@ -272,7 +409,7 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
             await this.executeModelRequest(
                 model,
                 modelConfig,
-                messages,
+                processedMessages,
                 options,
                 progress,
                 _token,

--- a/src/providers/minimaxProvider.ts
+++ b/src/providers/minimaxProvider.ts
@@ -129,11 +129,13 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
      * 注意：只处理当前轮次的新消息（最后一条用户消息），历史消息已在上一轮处理过
      * @param messages 原始消息列表
      * @param modelConfig 模型配置
+     * @param token 取消信号，用户取消请求时停止图片预处理
      * @returns 处理后的消息列表
      */
     private async preprocessImagesInMessages(
         messages: Array<LanguageModelChatMessage>,
-        modelConfig: ModelConfig
+        modelConfig: ModelConfig,
+        token: CancellationToken
     ): Promise<Array<LanguageModelChatMessage>> {
         // 只对 Coding Plan 模型启用图片桥接
         const providerKey = this.getProviderKeyForModel(modelConfig);
@@ -148,7 +150,17 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
             return messages;
         }
 
+        // 用户取消时快速退出
+        if (token.isCancellationRequested) {
+            Logger.debug('MiniMax 图片桥接: 请求已取消，跳过图片预处理');
+            return messages;
+        }
+
         const visionTool = new MiniMaxVisionTool();
+        const abortController = new AbortController();
+        token.onCancellationRequested(() => {
+            abortController.abort();
+        });
 
         // 找到最后一条用户消息（当前轮次的新消息）
         let lastUserMessageIndex = -1;
@@ -192,6 +204,10 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
         // 再处理图片部分
         const imageDescriptions: string[] = [];
         for (const part of lastUserMessage.content) {
+            if (token.isCancellationRequested) {
+                Logger.debug('MiniMax 图片桥接: 请求已取消，停止图片预处理');
+                return messages;
+            }
             if (part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/')) {
                 if (!this.isImageMimeType(part.mimeType)) {
                     Logger.error(`不支持的图片格式: ${part.mimeType}`);
@@ -205,10 +221,14 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
                         const visionPrompt = originalQuestion
                             ? `这是第${processedCount}张（共${totalImages}张）。用户的问题是：${originalQuestion}\n\n请详细描述这张图片的内容，力求准确完整。`
                             : `这是第${processedCount}张（共${totalImages}张）。\n\n请详细描述这张图片的内容，力求准确完整。`;
-                        const response = await visionTool.understandImage(part.data, part.mimeType, visionPrompt);
+                        const response = await visionTool.understandImage(part.data, part.mimeType, visionPrompt, abortController.signal);
                         imageDescriptions.push(response.content);
                         Logger.info(`图片 ${processedCount}/${totalImages} 转换成功`);
                     } catch (error) {
+                        if (abortController.signal.aborted) {
+                            Logger.debug('MiniMax 图片桥接: 请求已取消');
+                            return messages;
+                        }
                         Logger.error(`图片 ${processedCount}/${totalImages} 转换失败`, error instanceof Error ? error : undefined);
                         imageDescriptions.push('[图片分析失败]');
                     }
@@ -232,11 +252,15 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
         }
         bridgedContent.push(new vscode.LanguageModelTextPart(`\n用户问题：${originalQuestion}`));
 
-        // 直接修改原消息的内容，不创建新数组
-        // 使用类型断言因为 LanguageModelChatMessage 的 content 是只读的
-        (lastUserMessage as unknown as { content: typeof bridgedContent }).content = bridgedContent;
+        // 构造新的用户消息对象，不修改原始消息（避免只读属性问题）
+        const bridgedLastUserMessage = vscode.LanguageModelChatMessage.User(bridgedContent);
 
-        return messages;
+        // 返回新的 messages 数组
+        return [
+            ...messages.slice(0, lastUserMessageIndex),
+            bridgedLastUserMessage,
+            ...messages.slice(lastUserMessageIndex + 1)
+        ];
     }
 
     /**
@@ -373,7 +397,8 @@ export class MiniMaxProvider extends GenericModelProvider implements LanguageMod
         // 图片桥接：预处理消息中的图片
         // 当模型不支持图片输入但使用 Coding Plan 密钥时，自动将图片转换为文字描述
         // 注意：此操作在 Token 统计之前执行，确保统计的是模型实际收到的文本描述而非原始图片
-        const processedMessages = await this.preprocessImagesInMessages(messages, modelConfig);
+        // 同时透传 CancellationToken，用户取消请求时自动中止 Vision 预处理
+        const processedMessages = await this.preprocessImagesInMessages(messages, modelConfig, _token);
 
         // 计算输入 token 数量并更新状态栏（使用桥接后的消息，图片已被替换为文本描述）
         const totalInputTokens = await this.updateContextUsageStatusBar(

--- a/src/tools/minimaxVision.ts
+++ b/src/tools/minimaxVision.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  MiniMax 图片理解工具
+ *  使用 Coding Plan API 直接进行 HTTP 请求
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as https from 'https';
+import { ConfigManager, Logger } from '../utils';
+import { ApiKeyManager } from '../utils/apiKeyManager';
+import { VersionManager } from '../utils/versionManager';
+import { StatusBarManager } from '../status';
+
+/**
+ * MiniMax 图片理解请求参数
+ */
+export interface MiniMaxVisionRequest {
+    prompt: string; // 问题或分析请求
+    image_url: string; // 图片地址（HTTP/HTTPS URL 或 data URL）
+}
+
+/**
+ * MiniMax 图片理解响应
+ */
+export interface MiniMaxVisionResponse {
+    content: string; // 图片分析结果文本
+}
+
+/**
+ * MiniMax 图片理解工具
+ */
+export class MiniMaxVisionTool {
+    private getBaseURL(): string {
+        // 根据接入点配置返回对应的 base URL
+        if (ConfigManager.getMinimaxEndpoint() === 'minimax.io') {
+            return 'https://api.minimax.io';
+        }
+        return 'https://api.minimaxi.com';
+    }
+
+    /**
+     * 执行图片理解
+     */
+    async understand(params: MiniMaxVisionRequest): Promise<MiniMaxVisionResponse> {
+        const apiKey = await ApiKeyManager.getApiKey('minimax-coding');
+        if (!apiKey) {
+            throw new Error('MiniMax Coding Plan API密钥未设置，请先运行命令"GCMP: 设置 MiniMax Coding Plan API密钥"');
+        }
+
+        const requestData = JSON.stringify({
+            prompt: params.prompt,
+            image_url: params.image_url
+        });
+
+        const requestUrl = `${this.getBaseURL()}/v1/coding_plan/vlm`;
+
+        const options = {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Length': Buffer.byteLength(requestData),
+                'User-Agent': VersionManager.getUserAgent('MiniMaxVision')
+            }
+        };
+
+        Logger.info(`🔍 [MiniMax 图片理解] 开始分析图片`);
+        Logger.debug(`📝 [MiniMax 图片理解] 请求数据: prompt="${params.prompt}", image_url=${params.image_url}`);
+
+        return new Promise((resolve, reject) => {
+            const req = https.request(requestUrl, options, res => {
+                let data = '';
+
+                res.on('data', chunk => {
+                    data += chunk;
+                });
+
+                res.on('end', () => {
+                    try {
+                        Logger.debug(`📊 [MiniMax 图片理解] 响应状态码: ${res.statusCode}`);
+                        Logger.debug(`📄 [MiniMax 图片理解] 响应数据: ${data}`);
+
+                        if (res.statusCode !== 200) {
+                            let errorMessage = `MiniMax图片理解API错误 ${res.statusCode}`;
+                            try {
+                                const errorData = JSON.parse(data);
+                                errorMessage += `: ${errorData.error?.message || JSON.stringify(errorData)}`;
+                            } catch {
+                                errorMessage += `: ${data}`;
+                            }
+                            Logger.error('❌ [MiniMax 图片理解] API返回错误', new Error(errorMessage));
+                            reject(new Error(errorMessage));
+                            return;
+                        }
+
+                        const response = JSON.parse(data) as MiniMaxVisionResponse;
+                        Logger.info(`✅ [MiniMax 图片理解] 分析完成`);
+                        resolve(response);
+                    } catch (error) {
+                        Logger.error('❌ [MiniMax 图片理解] 解析响应失败', error instanceof Error ? error : undefined);
+                        reject(
+                            new Error(
+                                `解析MiniMax图片理解响应失败: ${error instanceof Error ? error.message : '未知错误'}`
+                            )
+                        );
+                    }
+                });
+            });
+
+            req.on('error', error => {
+                Logger.error('❌ [MiniMax 图片理解] 请求失败', error);
+                reject(new Error(`MiniMax图片理解请求失败: ${error.message}`));
+            });
+
+            req.write(requestData);
+            req.end();
+        });
+    }
+
+    /**
+     * 直接理解图片数据（用于图片桥接功能）
+     * @param imageData 图片的二进制数据
+     * @param mimeType 图片的 MIME 类型
+     * @param prompt 可选的提示词，默认是"描述这张图片"
+     */
+    async understandImage(
+        imageData: Uint8Array,
+        mimeType: string,
+        prompt = '描述这张图片'
+    ): Promise<MiniMaxVisionResponse> {
+        // 将图片数据转换为 data URL
+        const base64Data = Buffer.from(imageData).toString('base64');
+        const dataUrl = `data:${mimeType};base64,${base64Data}`;
+
+        return this.understand({
+            prompt,
+            image_url: dataUrl
+        });
+    }
+
+    /**
+     * 工具调用处理器
+     */
+    async invoke(
+        request: vscode.LanguageModelToolInvocationOptions<MiniMaxVisionRequest>
+    ): Promise<vscode.LanguageModelToolResult> {
+        try {
+            Logger.info(`🚀 [工具调用] MiniMax图片理解工具被调用: ${JSON.stringify(request.input)}`);
+
+            const params = request.input as MiniMaxVisionRequest;
+            if (!params.prompt) {
+                throw new Error('缺少必需参数: prompt');
+            }
+            if (!params.image_url) {
+                throw new Error('缺少必需参数: image_url');
+            }
+
+            const response = await this.understand(params);
+            Logger.info('✅ [工具调用] MiniMax图片理解工具调用成功');
+
+            StatusBarManager.minimax?.delayedUpdate();
+
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(response.content)
+            ]);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : '未知错误';
+            Logger.error('❌ [工具调用] MiniMax图片理解工具调用失败', error instanceof Error ? error : undefined);
+            throw new vscode.LanguageModelError(`MiniMax图片理解失败: ${errorMessage}`);
+        }
+    }
+
+    /**
+     * 清理工具资源
+     */
+    async cleanup(): Promise<void> {
+        try {
+            Logger.info('✅ [MiniMax 图片理解] 工具资源已清理');
+        } catch (error) {
+            Logger.error('❌ [MiniMax 图片理解] 资源清理失败', error instanceof Error ? error : undefined);
+        }
+    }
+}

--- a/src/tools/minimaxVision.ts
+++ b/src/tools/minimaxVision.ts
@@ -39,8 +39,10 @@ export class MiniMaxVisionTool {
 
     /**
      * 执行图片理解
+     * @param params 请求参数
+     * @param abortSignal 取消信号
      */
-    async understand(params: MiniMaxVisionRequest): Promise<MiniMaxVisionResponse> {
+    async understand(params: MiniMaxVisionRequest, abortSignal?: AbortSignal): Promise<MiniMaxVisionResponse> {
         const apiKey = await ApiKeyManager.getApiKey('minimax-coding');
         if (!apiKey) {
             throw new Error('MiniMax Coding Plan API密钥未设置，请先运行命令"GCMP: 设置 MiniMax Coding Plan API密钥"');
@@ -63,8 +65,7 @@ export class MiniMaxVisionTool {
             }
         };
 
-        Logger.info(`🔍 [MiniMax 图片理解] 开始分析图片`);
-        Logger.debug(`📝 [MiniMax 图片理解] 请求数据: prompt="${params.prompt}", image_url=${params.image_url}`);
+        Logger.info('[MiniMax 图片理解] 开始分析图片');
 
         return new Promise((resolve, reject) => {
             const req = https.request(requestUrl, options, res => {
@@ -76,8 +77,7 @@ export class MiniMaxVisionTool {
 
                 res.on('end', () => {
                     try {
-                        Logger.debug(`📊 [MiniMax 图片理解] 响应状态码: ${res.statusCode}`);
-                        Logger.debug(`📄 [MiniMax 图片理解] 响应数据: ${data}`);
+                        Logger.debug(`[MiniMax 图片理解] 响应状态码: ${res.statusCode}`);
 
                         if (res.statusCode !== 200) {
                             let errorMessage = `MiniMax图片理解API错误 ${res.statusCode}`;
@@ -87,16 +87,16 @@ export class MiniMaxVisionTool {
                             } catch {
                                 errorMessage += `: ${data}`;
                             }
-                            Logger.error('❌ [MiniMax 图片理解] API返回错误', new Error(errorMessage));
+                            Logger.error('[MiniMax 图片理解] API返回错误', new Error(errorMessage));
                             reject(new Error(errorMessage));
                             return;
                         }
 
                         const response = JSON.parse(data) as MiniMaxVisionResponse;
-                        Logger.info(`✅ [MiniMax 图片理解] 分析完成`);
+                        Logger.info('[MiniMax 图片理解] 分析完成');
                         resolve(response);
                     } catch (error) {
-                        Logger.error('❌ [MiniMax 图片理解] 解析响应失败', error instanceof Error ? error : undefined);
+                        Logger.error('[MiniMax 图片理解] 解析响应失败', error instanceof Error ? error : undefined);
                         reject(
                             new Error(
                                 `解析MiniMax图片理解响应失败: ${error instanceof Error ? error.message : '未知错误'}`
@@ -107,9 +107,27 @@ export class MiniMaxVisionTool {
             });
 
             req.on('error', error => {
-                Logger.error('❌ [MiniMax 图片理解] 请求失败', error);
+                if (abortSignal?.aborted) {
+                    reject(new Error('用户取消了图片理解请求'));
+                    return;
+                }
+                Logger.error('[MiniMax 图片理解] 请求失败', error);
                 reject(new Error(`MiniMax图片理解请求失败: ${error.message}`));
             });
+
+            // 请求超时：60 秒
+            req.setTimeout(60000, () => {
+                req.destroy();
+                Logger.error('[MiniMax 图片理解] 请求超时（60秒）');
+                reject(new Error('MiniMax图片理解请求超时（60秒）'));
+            });
+
+            // 取消信号监听
+            if (abortSignal) {
+                abortSignal.addEventListener('abort', () => {
+                    req.destroy();
+                });
+            }
 
             req.write(requestData);
             req.end();
@@ -121,20 +139,23 @@ export class MiniMaxVisionTool {
      * @param imageData 图片的二进制数据
      * @param mimeType 图片的 MIME 类型
      * @param prompt 可选的提示词，默认是"描述这张图片"
+     * @param abortSignal 取消信号
      */
     async understandImage(
         imageData: Uint8Array,
         mimeType: string,
-        prompt = '描述这张图片'
+        prompt = '描述这张图片',
+        abortSignal?: AbortSignal
     ): Promise<MiniMaxVisionResponse> {
-        // 将图片数据转换为 data URL
+        // 将图片数据转换为 data URL（不记录完整 data URL，仅记录元信息）
         const base64Data = Buffer.from(imageData).toString('base64');
         const dataUrl = `data:${mimeType};base64,${base64Data}`;
+        Logger.debug(`[MiniMax 图片理解] 请求: prompt="${prompt}", mimeType=${mimeType}, data大小=${imageData.length}字节`);
 
         return this.understand({
             prompt,
             image_url: dataUrl
-        });
+        }, abortSignal);
     }
 
     /**
@@ -144,9 +165,15 @@ export class MiniMaxVisionTool {
         request: vscode.LanguageModelToolInvocationOptions<MiniMaxVisionRequest>
     ): Promise<vscode.LanguageModelToolResult> {
         try {
-            Logger.info(`🚀 [工具调用] MiniMax图片理解工具被调用: ${JSON.stringify(request.input)}`);
-
             const params = request.input as MiniMaxVisionRequest;
+            // 日志不输出完整 data URL，仅记录 prompt 和图片元信息
+            const imageMeta = params.image_url
+                ? params.image_url.length > 50
+                    ? `${params.image_url.substring(0, 20)}...${params.image_url.slice(-10)} (${params.image_url.length} chars)`
+                    : params.image_url
+                : '未提供';
+            Logger.info(`[工具调用] MiniMax图片理解工具被调用: prompt="${params.prompt}", image_url=${imageMeta}`);
+
             if (!params.prompt) {
                 throw new Error('缺少必需参数: prompt');
             }


### PR DESCRIPTION
## 改动概述

为 MiniMax Coding Plan 模型添加图片桥接功能。当用户向 Coding Plan 模型发送截图、照片等图片时，自动调用 MiniMax Vision API 将图片转换为文字描述，再发送给主模型。

**适用场景：** MiniMax Coding Plan 模型（`minimax-coding`）本身不支持直接接收图片输入，但 MiniMax 提供了独立的 Vision API（`/v1/coding_plan/vlm`），此功能将两者串联。

## 改动文件

### 1. `src/providers/config/minimax.json`
- Coding Plan 模型的 `capabilities.imageInput` 从 `false` 改为 `true`

### 2. `src/tools/minimaxVision.ts`（新增）
- 新建 `MiniMaxVisionTool` 类，封装 Vision API 调用
- 根据 `ConfigManager.getMinimaxEndpoint()` 自动切换国内/国际站 base URL
- 提供 `understandImage(data, mimeType, prompt)` 方法

### 3. `src/providers/minimaxProvider.ts`
- 新增 `preprocessImagesInMessages()`：检测图片 parts，调用 Vision API 转换，in-place 替换消息内容
- 图片桥接在 token 统计之前执行，确保状态栏反映文本描述量

## 消息格式

用户发送 2 张图片 + 问题后，主模型收到的消息结构：

```
你（主模型）不支持直接接收图片，用户共上传了2张图片。以下是由视觉模型对这些图片的分析结果，以及用户的原始问题。

图片内容（共2张）：
1. [Vision API 对第1张的描述]
2. [Vision API 对第2张的描述]

用户问题：xxx
```

## 测试验证清单

- [x] 单张 PNG/JPG 能正确转换为文字描述
- [x] 多张图片各自分别调用 Vision API
- [x] 第二轮对话（追问）时图片不再重复桥接
- [x] 状态栏 token 统计反映文本描述量而非原始图片

<img width="1040" height="1828" alt="image" src="https://github.com/user-attachments/assets/098f1cbc-2ab8-45a4-b899-cfa219afd000" />
