### PR TITLE
fix(commit): 将默认 scope 改为 staged，仅基于暂存区生成提交消息

### DIFF
--- a/src/commit/commitMessage.ts
+++ b/src/commit/commitMessage.ts
@@ -170,11 +170,11 @@ export class CommitMessage {
         progress: vscode.Progress<{ message?: string; increment?: number }>,
         repository: Repository,
         token: vscode.CancellationToken,
-        scope: 'config' | 'staged' | 'workingTree' = 'config'
+        scope: 'config' | 'staged' | 'workingTree' = 'staged'
     ): Promise<{ message: string; model: string }> {
         const repoPath = repository.rootUri.fsPath;
         const commitConfig = ConfigManager.getCommitConfig();
-        // 仅 staged 入口才启用 staged-only；默认入口始终分析完整变更（staged + working tree）。
+        // 默认入口仅分析 staged 变更（与提交语义一致）。
         const onlyStagedChanges = scope === 'staged';
 
         // 1. 获取 Git 变更


### PR DESCRIPTION
## 问题

当前 `generateCommitMessage` 的默认 scope 是 `'config'`，会分析所有变更（staged + working tree）。这导致两个问题：

1. **与 git commit 的语义不一致**：`git commit` 只提交已暂存的文件，生成的 commit message 却包含了未暂存的变更，内容容易与实际提交不符
2. **其他主流工具的行为**：GitHub Copilot Commit Message、SourceGraph、aider、cursor 等工具的 commit message 生成功能，默认都只基于 staged changes 生成消息

## 修改

将 `generateCommitMessage` 的默认 scope 从 `'config'` 改为 `'staged'`，使默认行为与 git commit 语义一致：

```diff
- scope: 'config' | 'staged' | 'workingTree' = 'config'
+ scope: 'config' | 'staged' | 'workingTree' = 'staged'
```

用户仍可通过配置 `"commit.scope": "workingTree"` 或 `"commit.scope": "config"` 恢复旧行为。

---

> 本 PR 来自 fork `cl1107/GCMP`，主分支 `main`（无额外 commit）。
