### PR TITLE
fix: 防止 deduplicateToolArgs 误删单字符标点导致工具调用参数解析失败

### DIFF
--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -284,8 +284,10 @@ export class StreamReporter {
      * 去重工具调用参数（处理 DeepSeek 等 API 的重复片段）
      */
     private deduplicateToolArgs(existing: string, newArgs: string): string {
-        // 完全重复，跳过
-        if (existing.endsWith(newArgs)) {
+        // 仅对长度 >= 2 的片段进行完全去重，避免单字符（如 " 、,、}）被误判为重复
+        // 例如累积到 ...\" 时末尾字符是 "，传入的单字符 " 会被 endsWith 误匹配并丢弃，
+        // 导致 JSON 字符串缺少闭合引号，最终解析失败
+        if (newArgs.length >= 2 && existing.endsWith(newArgs)) {
             Logger.trace(`[${this.modelName}] 跳过重复的工具调用参数: "${newArgs}"`);
             return existing;
         }


### PR DESCRIPTION
 修复#172 中提到的工具调用错误

## 变更内容
针对 `streamReporter.ts` 中的 `deduplicateToolArgs` 方法进行了优化：
- **限制去重判断条件**：将 `endsWith` 的去重判断限制为 `newArgs.length >= 2`。
- **目的**：确保单字符（如 JSON 的引号、逗号、括号）不会因为刚好匹配到 `existing` 的末尾而被错误丢弃。

## 验证结果 
- **测试环境**：DeepSeek V4 Flash (opencode go)
- **验证结论**：修复后工具调用解析稳定
- **验证日志**：
  - `2026-05-13 11:39:21.454 [info] [DeepSeek V4 Flash] 成功处理工具调用...` ✅
