### PR TITLE
fix: ignore identical cumulative snapshot resend

### DIFF
--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -310,6 +310,10 @@ export class StreamReporter {
             return newArgs;
         }
 
+        if (newArgs === existing) {
+            return existing;
+        }
+
         if (newArgs.length > existing.length && newArgs.startsWith(existing)) {
             return newArgs;
         }


### PR DESCRIPTION
Follow-up to #194.

This fixes an additional edge case in streamed tool-call argument merging.

When a snapshot-style gateway resends a fragment that is exactly identical to the current buffered arguments, the current logic falls through to append-only concatenation and duplicates the JSON buffer, which can prevent JSON.parse from completing.

This change treats `newArgs === existing` as a no-op, while keeping the existing cumulative-snapshot replacement path and append-only behavior.

Validated locally with minimal cases for:
- identical cumulative snapshot resend
- longer cumulative snapshot replacement
- append-only repeated substring cases fixed in #194