### PR TITLE
feat: add Charm Hyper provider with 17 models

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "onLanguageModelProvider:gcmp.grok",
         "onLanguageModelProvider:gcmp.baidu",
         "onLanguageModelProvider:gcmp.opencode",
+        "onLanguageModelProvider:gcmp.hyper",
         "onLanguageModelProvider:gcmp.compatible",
         "onLanguageModelTool:gcmp_zhipuWebSearch",
         "onLanguageModelTool:gcmp_minimaxWebSearch",
@@ -240,6 +241,11 @@
             {
                 "command": "gcmp.opencode.setApiKey",
                 "title": "%command.opencode.setApiKey%",
+                "category": "GCMP"
+            },
+            {
+                "command": "gcmp.hyper.setApiKey",
+                "title": "%command.hyper.setApiKey%",
                 "category": "GCMP"
             },
             {
@@ -772,6 +778,11 @@
                 "vendor": "gcmp.opencode",
                 "displayName": "GCMP · OpenCode",
                 "managementCommand": "gcmp.opencode.setApiKey"
+            },
+            {
+                "vendor": "gcmp.hyper",
+                "displayName": "GCMP · Charm Hyper",
+                "managementCommand": "gcmp.hyper.setApiKey"
             },
             {
                 "vendor": "gcmp.gemini",

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,6 +34,7 @@
     "command.codex.configWizard": "Codex CLI Configuration Wizard (CLI Auth)",
     "command.grok.configWizard": "Grok Build Configuration Wizard (CLI Auth)",
     "command.opencode.setApiKey": "Set OpenCode API Key",
+    "command.hyper.setApiKey": "Set Charm Hyper API Key",
     "command.compatible.manageModels": "Compatible Provider Settings",
     "command.nesCompletion.toggleManual": "Toggle NES Manual Trigger Mode",
     "command.tokenUsage.showDetails": "View Today's Token Usage Details",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -34,6 +34,7 @@
     "command.codex.configWizard": "Codex CLI 配置向导（CLI 认证）",
     "command.grok.configWizard": "Grok Build 配置向导（CLI 认证）",
     "command.opencode.setApiKey": "设置 OpenCode API 密钥",
+    "command.hyper.setApiKey": "设置 Charm Hyper API 密钥",
     "command.compatible.manageModels": "Compatible Provider 设置",
     "command.nesCompletion.toggleManual": "切换 NES 手动触发模式",
     "command.tokenUsage.showDetails": "查看今日 Token 消耗统计详情",

--- a/src/providers/config/hyper.json
+++ b/src/providers/config/hyper.json
@@ -1,0 +1,272 @@
+{
+    "displayName": "Charm Hyper",
+    "baseUrl": "https://hyper.charm.land/v1",
+    "apiKeyTemplate": "sk-hyper-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "models": [
+        {
+            "id": "deepseek-v4-flash",
+            "name": "DeepSeek-V4-Flash",
+            "tooltip": "DeepSeek V4 Flash — 快速推理模式，支持百万上下文与图像输入",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 384000,
+            "reasoningEffort": [
+                "none",
+                "high",
+                "xhigh"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "deepseek-v4-pro",
+            "name": "DeepSeek-V4-Pro",
+            "tooltip": "DeepSeek V4 Pro — 专家推理模式，百万上下文",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 384000,
+            "reasoningEffort": [
+                "none",
+                "high",
+                "xhigh"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "gemma-4-26b-a4b-it",
+            "name": "Gemma 4 26B A4B",
+            "tooltip": "Google Gemma 4 26B A4B 指令微调版",
+            "maxInputTokens": 256000,
+            "maxOutputTokens": 25600,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "glm-5",
+            "name": "GLM-5",
+            "tooltip": "智谱 GLM-5 旗舰基座模型",
+            "maxInputTokens": 202752,
+            "maxOutputTokens": 20275,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "glm-5.1",
+            "name": "GLM-5.1",
+            "tooltip": "智谱 GLM-5.1 — 最新旗舰基座，支持图像输入",
+            "maxInputTokens": 202800,
+            "maxOutputTokens": 64000,
+            "reasoningEffort": [
+                "none",
+                "low",
+                "medium",
+                "high"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "gpt-oss-120b",
+            "name": "GPT-OSS-120B",
+            "tooltip": "OpenAI 开源的 GPT-OSS 120B 模型",
+            "maxInputTokens": 131072,
+            "maxOutputTokens": 13107,
+            "reasoningEffort": [
+                "none",
+                "low",
+                "medium",
+                "high"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "kimi-k2.5",
+            "name": "Kimi K2.5",
+            "tooltip": "MoonshotAI Kimi K2.5 全能模型",
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 26214,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "kimi-k2.6",
+            "name": "Kimi K2.6",
+            "tooltip": "MoonshotAI Kimi K2.6 — 最新版，支持图像输入",
+            "maxInputTokens": 262000,
+            "maxOutputTokens": 262000,
+            "reasoningEffort": [
+                "none",
+                "low",
+                "medium",
+                "high"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "llama-3.3-70b-instruct",
+            "name": "Llama 3.3 70B Instruct",
+            "tooltip": "Meta Llama 3.3 70B 指令微调版",
+            "maxInputTokens": 128000,
+            "maxOutputTokens": 12800,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "llama-4-maverick-17b-128e-instruct-fp8",
+            "name": "Llama 4 Maverick 17B 128E Instruct FP8",
+            "tooltip": "Meta Llama 4 Maverick MoE 指令微调版 (FP8)",
+            "maxInputTokens": 430000,
+            "maxOutputTokens": 43000,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "minimax-m2.7",
+            "name": "MiniMax M2.7",
+            "tooltip": "MiniMax M2.7 极速推理模型",
+            "maxInputTokens": 204800,
+            "maxOutputTokens": 131000,
+            "reasoningEffort": [
+                "none",
+                "low",
+                "medium",
+                "high"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "qwen3.6-flash",
+            "name": "Qwen3.6-Flash",
+            "tooltip": "阿里 Qwen3.6 Flash — 轻量快速，百万上下文，支持图像输入",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 64000,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "qwen3.6-max",
+            "name": "Qwen3.6-Max",
+            "tooltip": "阿里 Qwen3.6 Max — 旗舰版",
+            "maxInputTokens": 256000,
+            "maxOutputTokens": 64000,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "qwen3.6-plus",
+            "name": "Qwen3.6-Plus",
+            "tooltip": "阿里 Qwen3.6 Plus — 增强版，百万上下文，支持图像输入",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 64000,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "qwen3.7-max",
+            "name": "Qwen3.7-Max",
+            "tooltip": "阿里 Qwen3.7 Max — 最新旗舰版",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 64000,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "qwen3-coder-480b-a35b-instruct-int4-mixed-ar",
+            "name": "Qwen3 Coder 480B A35B Instruct INT4",
+            "tooltip": "阿里 Qwen3 Coder MoE 480B — 编程专用模型",
+            "maxInputTokens": 106000,
+            "maxOutputTokens": 10600,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        },
+        {
+            "id": "qwen3-next-80b-a3b-instruct",
+            "name": "Qwen3 Next 80B A3B Instruct",
+            "tooltip": "阿里 Qwen3 Next MoE 80B 指令微调版",
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 26214,
+            "thinking": [
+                "disabled",
+                "enabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": false
+            }
+        }
+    ]
+}

--- a/src/providers/config/index.ts
+++ b/src/providers/config/index.ts
@@ -14,6 +14,7 @@ import gemini from './gemini.json';
 import codex from './codex.json';
 import grok from './grok.json';
 import opencode from './opencode.json';
+import hyper from './hyper.json';
 
 const providers = {
     zhipu,
@@ -29,7 +30,8 @@ const providers = {
     gemini,
     codex,
     grok,
-    opencode
+    opencode,
+    hyper
 };
 
 export type ProviderName = keyof typeof providers;


### PR DESCRIPTION
- Add hyper.json config with models from https://hyper.charm.land/v1/models
- Register in config/index.ts, package.json (activationEvents, commands, languageModelChatProviders)
- Add localization strings (en/zh-cn)
- Uses GenericModelProvider with OpenAI-compatible API