### PR TITLE
添加 Grok 提供的 Composer 2.5 (fast) 模型，调整输入token，避免实际上下文超限

### DIFF
--- a/src/providers/config/grok.json
+++ b/src/providers/config/grok.json
@@ -8,8 +8,20 @@
             "name": "Grok Build 0.1",
             "tooltip": "xAI 的 Grok Build 编程模型，通过 Grok Build OAuth 登录态访问。",
             "sdkMode": "openai-responses",
-            "maxInputTokens": 256000,
-            "maxOutputTokens": 131072,
+            "maxInputTokens": 190464,
+            "maxOutputTokens": 65536,
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
+            "id": "grok-composer-2.5-fast",
+            "name": "Grok Composer 2.5 (fast)",
+            "tooltip": "Cursor 的 Composer 2.5 (fast) 编程模型，通过 Grok Build OAuth 登录态访问。",
+            "sdkMode": "openai-responses",
+            "maxInputTokens": 134464,
+            "maxOutputTokens": 65536,
             "capabilities": {
                 "toolCalling": true,
                 "imageInput": true


### PR DESCRIPTION
grok和cursor合作加了 composer 2.5 fast 模型，实测效果比 grok-build-0.1 好（主要是 build-0.1 对 copilot 的工具调用不太熟，开头要重试几次才能成功）
另外调整了一下输入token的上限，因为我发现vscode的上下文尺寸是input+output，所以如果input = context size，就会在最后直接挂掉，不过我不确定输出65536是否够用
composer 2.5目前没有明确的参数，但根据官方文档说上下文是200K我就这样填了