### PR TITLE
feat: 新增自定义 modelsEndpoint 配置

### DIFF
--- a/src/providers/compatibleProvider.ts
+++ b/src/providers/compatibleProvider.ts
@@ -96,6 +96,7 @@ export class CompatibleProvider extends GenericModelProvider {
                     capabilities: model.capabilities,
                     ...(model.baseUrl && { baseUrl: model.baseUrl }),
                     ...(model.endpoint && { endpoint: model.endpoint }),
+                    ...(model.modelsEndpoint && { modelsEndpoint: model.modelsEndpoint }),
                     ...(model.model && { model: model.model }),
                     ...(customHeader && { customHeader: customHeader }),
                     ...(model.extraBody && { extraBody: model.extraBody }),

--- a/src/ui/modelEditor.js
+++ b/src/ui/modelEditor.js
@@ -60,6 +60,8 @@ function isValidProxyInput(value) {
  * @property {string} [tooltip] - 描述（可选）
  * @property {string} provider - 提供商标识符
  * @property {string} [baseUrl] - API基础URL（可选）
+ * @property {string} [endpoint] - 自定义聊天端点（可选）
+ * @property {string} [modelsEndpoint] - 自定义模型列表端点（可选）
  * @property {string} [proxy] - 代理服务器地址（可选）
  * @property {string} [model] - 请求模型ID（可选）
  * @property {'openai'|'openai-sse'|'openai-responses'|'anthropic'|'gemini-sse'} sdkMode - SDK兼容模式
@@ -211,6 +213,28 @@ function createDOM() {
         }, t(
             'Base URL used for API requests. It must start with http:// or https://.\r\nFor example: https://api.openai.com/v1 or https://api.anthropic.com',
             'API请求的 baseUrl 地址，必须以 http:// 或 https:// 开头\r\n例如：https://api.openai.com/v1 或 https://api.anthropic.com'
+        )),
+        createFormGroup('endpoint', t('Chat Endpoint', '聊天端点'), 'endpoint', 'input', {
+            type: 'text',
+            placeholder: t(
+                'e.g. /chat/completions or https://api.example.com/chat/completions',
+                '例如：/chat/completions 或 https://api.example.com/chat/completions'
+            ),
+            value: modelData.endpoint || ''
+        }, t(
+            'Optional custom endpoint used for chat requests. Supports either a relative path or a full URL.',
+            '可选的自定义聊天请求端点。支持相对路径或完整 URL。'
+        )),
+        createFormGroup('modelsEndpoint', t('Models Endpoint', '模型列表端点'), 'modelsEndpoint', 'input', {
+            type: 'text',
+            placeholder: t(
+                'e.g. /models, /v4/models, or https://api.example.com/v4/models',
+                '例如：/models、/v4/models 或 https://api.example.com/v4/models'
+            ),
+            value: modelData.modelsEndpoint || ''
+        }, t(
+            'Optional custom endpoint used by the "Fetch Models" button. Supports either a relative path or a full URL.',
+            '“获取模型”按钮使用的可选自定义模型列表端点。支持相对路径或完整 URL。'
         )),
         createFormGroup('proxy', t('Proxy URL', '代理 URL'), 'proxy', 'input', {
             type: 'text',
@@ -1009,6 +1033,8 @@ function bindEvents() {
     const modelName = document.getElementById('modelName');
     const provider = document.getElementById('provider');
     const baseUrl = document.getElementById('baseUrl');
+    const endpoint = document.getElementById('endpoint');
+    const modelsEndpoint = document.getElementById('modelsEndpoint');
     const maxInputTokens = document.getElementById('maxInputTokens');
     const maxOutputTokens = document.getElementById('maxOutputTokens');
 
@@ -1043,6 +1069,31 @@ function bindEvents() {
         } catch (e) {
             this.classList.add('invalid');
         }
+    });
+
+    [endpoint, modelsEndpoint].forEach(input => {
+        input.addEventListener('input', function () {
+            const value = this.value.trim();
+            if (!value) {
+                this.classList.remove('invalid');
+                return;
+            }
+            if (value.startsWith('http://') || value.startsWith('https://')) {
+                try {
+                    const urlObj = new URL(value);
+                    if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+                        this.classList.remove('invalid');
+                    } else {
+                        this.classList.add('invalid');
+                    }
+                } catch (e) {
+                    this.classList.add('invalid');
+                }
+                return;
+            }
+
+            this.classList.remove('invalid');
+        });
     });
 
     // Token数量验证
@@ -1451,6 +1502,8 @@ function validateForm() {
     const modelName = document.getElementById('modelName').value.trim();
     const provider = document.getElementById('provider').value.trim();
     const baseUrl = document.getElementById('baseUrl').value.trim();
+    const endpoint = document.getElementById('endpoint').value.trim();
+    const modelsEndpoint = document.getElementById('modelsEndpoint').value.trim();
     const proxyUrl = normalizeProxyInput(document.getElementById('proxy').value);
     const maxInputTokens = document.getElementById('maxInputTokens').value.trim();
     const maxOutputTokens = document.getElementById('maxOutputTokens').value.trim();
@@ -1515,6 +1568,39 @@ function validateForm() {
         );
         document.getElementById('proxy').focus();
         return false;
+    }
+
+    const endpointFields = [
+        {
+            value: endpoint,
+            id: 'endpoint',
+            invalidMessage: t('Chat endpoint is invalid. Enter a valid URL or path.', '聊天端点格式不正确，请输入有效的 URL 或路径')
+        },
+        {
+            value: modelsEndpoint,
+            id: 'modelsEndpoint',
+            invalidMessage: t('Models endpoint is invalid. Enter a valid URL or path.', '模型列表端点格式不正确，请输入有效的 URL 或路径')
+        }
+    ];
+
+    for (const field of endpointFields) {
+        if (!field.value) {
+            continue;
+        }
+        if (field.value.startsWith('http://') || field.value.startsWith('https://')) {
+            try {
+                const urlObj = new URL(field.value);
+                if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+                    showGlobalError(field.invalidMessage);
+                    document.getElementById(field.id).focus();
+                    return false;
+                }
+            } catch (e) {
+                showGlobalError(field.invalidMessage);
+                document.getElementById(field.id).focus();
+                return false;
+            }
+        }
     }
 
     // 验证 Token 数量
@@ -1584,6 +1670,8 @@ function saveModel() {
     const tooltipText = document.getElementById('modelTooltip').value.trim();
     const requestModelText = document.getElementById('requestModel').value.trim();
     const baseUrlText = document.getElementById('baseUrl').value.trim();
+    const endpointText = document.getElementById('endpoint').value.trim();
+    const modelsEndpointText = document.getElementById('modelsEndpoint').value.trim();
     const proxyText = normalizeProxyInput(document.getElementById('proxy').value);
     const apiKeyText = document.getElementById('apiKey').value.trim();
 
@@ -1600,6 +1688,10 @@ function saveModel() {
     model.provider = provider;
     // baseUrl: 使用 null 表示清空
     model.baseUrl = baseUrlText || null;
+    // endpoint: 使用 null 表示清空
+    model.endpoint = endpointText || null;
+    // modelsEndpoint: 使用 null 表示清空
+    model.modelsEndpoint = modelsEndpointText || null;
     // proxy: 使用 null 表示清空
     model.proxy = proxyText || null;
     // apiKey: 使用 null 表示清空
@@ -1685,6 +1777,7 @@ function deleteModel() {
  */
 function fetchModelsFromAPI() {
     const baseUrl = document.getElementById('baseUrl').value.trim();
+    const modelsEndpoint = document.getElementById('modelsEndpoint').value.trim();
     const proxy = normalizeProxyInput(document.getElementById('proxy').value);
     const apiKey = document.getElementById('apiKey').value.trim();
     const provider = document.getElementById('provider').value.trim();
@@ -1706,10 +1799,24 @@ function fetchModelsFromAPI() {
         return;
     }
 
+    if (modelsEndpoint && (modelsEndpoint.startsWith('http://') || modelsEndpoint.startsWith('https://'))) {
+        try {
+            const urlObj = new URL(modelsEndpoint);
+            if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+                showGlobalError(t('Models endpoint must start with http:// or https://.', '模型列表端点必须以 http:// 或 https:// 开头'));
+                return;
+            }
+        } catch (e) {
+            showGlobalError(t('Models endpoint is invalid. Enter a valid URL or path.', '模型列表端点格式不正确，请输入有效的 URL 或路径'));
+            return;
+        }
+    }
+
     // 发送请求到后端
     vscode.postMessage({
         command: 'fetchModels',
         baseUrl: baseUrl,
+        modelsEndpoint: modelsEndpoint || null,
         proxy: proxy || null,
         apiKey: apiKey || null,
         provider: provider || null

--- a/src/ui/modelEditor.ts
+++ b/src/ui/modelEditor.ts
@@ -19,6 +19,19 @@ interface EditedModelConfig extends CompatibleModelConfig {
     /** API密钥（可选，如果提供，将会自动设置API key） */
     apiKey?: string;
 }
+
+interface EndpointResolutionResult {
+    ok: true;
+    url: string;
+}
+
+interface EndpointResolutionError {
+    ok: false;
+    error: string;
+}
+
+type EndpointResolution = EndpointResolutionResult | EndpointResolutionError;
+
 /**
  * 删除模型标记接口
  */
@@ -74,6 +87,7 @@ export class ModelEditor {
                                 await this.fetchModelsFromAPI(
                                     panel.webview,
                                     message.baseUrl,
+                                    message.modelsEndpoint,
                                     message.apiKey,
                                     message.provider,
                                     message.proxy
@@ -158,6 +172,8 @@ export class ModelEditor {
             sdkMode: model?.sdkMode || 'openai',
             tooltip: model?.tooltip || '',
             baseUrl: model?.baseUrl || '',
+            endpoint: model?.endpoint || '',
+            modelsEndpoint: model?.modelsEndpoint || '',
             proxy: model?.proxy || '',
             model: model?.model || '',
             maxInputTokens: model?.maxInputTokens || 128000,
@@ -262,6 +278,7 @@ export class ModelEditor {
     private static async fetchModelsFromAPI(
         webview: vscode.Webview,
         baseUrl: string,
+        modelsEndpoint?: string,
         apiKey?: string,
         provider?: string,
         proxy?: string
@@ -276,22 +293,16 @@ export class ModelEditor {
                 return;
             }
 
-            // 构建完整的 URL
-            let url = baseUrl.trim();
-            // 移除末尾的斜杠
-            url = url.replace(/\/+$/, '');
-
-            // 智能添加 /models 端点
-            // 如果 URL 不包含 /v1，则添加 /v1/models
-            // 如果已经包含 /v1，则只添加 /models
-            let modelsUrl: string;
-            if (url.includes('/v1')) {
-                // 已经包含 /v1，直接添加 /models
-                modelsUrl = `${url}/models`;
-            } else {
-                // 不包含 /v1，添加 /v1/models
-                modelsUrl = `${url}/v1/models`;
+            const modelsUrlResult = this.resolveModelsUrl(baseUrl, modelsEndpoint);
+            if (!modelsUrlResult.ok) {
+                webview.postMessage({
+                    command: 'modelsError',
+                    error: modelsUrlResult.error
+                });
+                return;
             }
+
+            const modelsUrl = modelsUrlResult.url;
 
             // 发送加载中状态
             webview.postMessage({
@@ -369,5 +380,52 @@ export class ModelEditor {
                 error: t('Failed to fetch model list: {0}', '获取模型列表失败: {0}', errorMessage)
             });
         }
+    }
+
+    private static resolveModelsUrl(baseUrl: string, modelsEndpoint?: string): EndpointResolution {
+        const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, '');
+        const normalizedModelsEndpoint = modelsEndpoint?.trim();
+
+        if (!normalizedModelsEndpoint) {
+            return {
+                ok: true,
+                url: `${normalizedBaseUrl}/models`
+            };
+        }
+
+        if (
+            normalizedModelsEndpoint.startsWith('http://')
+            || normalizedModelsEndpoint.startsWith('https://')
+        ) {
+            try {
+                const modelsUrl = new URL(normalizedModelsEndpoint);
+                if (modelsUrl.protocol !== 'http:' && modelsUrl.protocol !== 'https:') {
+                    return {
+                        ok: false,
+                        error: t(
+                            'Models endpoint must start with http:// or https://.',
+                            '模型列表端点必须以 http:// 或 https:// 开头'
+                        )
+                    };
+                }
+                return {
+                    ok: true,
+                    url: modelsUrl.toString().replace(/\/+$/, '')
+                };
+            } catch {
+                return {
+                    ok: false,
+                    error: t(
+                        'Models endpoint is invalid. Enter a valid URL or path.',
+                        '模型列表端点格式不正确，请输入有效的 URL 或路径'
+                    )
+                };
+            }
+        }
+
+        return {
+            ok: true,
+            url: `${normalizedBaseUrl}${normalizedModelsEndpoint.startsWith('/') ? normalizedModelsEndpoint : `/${normalizedModelsEndpoint}`}`
+        };
     }
 }

--- a/src/utils/compatibleModelManager.ts
+++ b/src/utils/compatibleModelManager.ts
@@ -49,6 +49,13 @@ export interface CompatibleModelConfig {
      * 仅对 openai、openai-sse、openai-responses 模式生效。
      */
     endpoint?: string;
+    /**
+     * 自定义模型列表端点路径（可选）
+     * 用于在“获取模型”时替换默认附加到 baseUrl 后的 /models 路径。
+     * - 相对路径（如 /models、/v4/models）：与 baseUrl 拼接使用
+     * - 完整 URL（如 https://api.example.com/v4/models）：直接作为请求地址
+     */
+    modelsEndpoint?: string;
     /** API请求时使用的模型名称（可选） */
     model?: string;
     /**

--- a/src/utils/jsonSchemaProvider.ts
+++ b/src/utils/jsonSchemaProvider.ts
@@ -514,6 +514,13 @@ export class JsonSchemaProvider {
                                 description: t('API base URL', 'API基础URL'),
                                 format: 'uri'
                             },
+                            modelsEndpoint: {
+                                type: 'string',
+                                description: t(
+                                    'Custom models endpoint path (optional).\nUsed to replace the default /models path appended to baseUrl when fetching the model list.\n- Relative path (for example /v4/models): concatenated with baseUrl\n- Full URL (for example https://api.example.com/v4/models): used directly as the request URL',
+                                    '自定义模型列表端点路径（可选）。\n用于在"获取模型"时替换默认附加到 baseUrl 后的 /models 路径。\n- 相对路径（如 /v4/models）：与 baseUrl 拼接使用\n- 完整 URL（如 https://api.example.com/v4/models）：直接作为请求地址'
+                                )
+                            },
                             model: {
                                 type: 'string',
                                 description: t(


### PR DESCRIPTION
## 问题描述

部分 API 服务不遵循 OpenAI 的 `/v1/models` 约定，此前 `fetchModelsFromAPI()` 总是将 `/v1/models` 或 `/models` 拼接到 `baseUrl` 后，导致请求 404（"获取模型列表失败: HTTP 404: Not Found"）。

## 解决方案

在模型编辑器中新增 `modelsEndpoint` 字段，允许用户自定义「获取模型列表」的端点路径。支持两种格式：

- **相对路径**（如 `/models`、`/v4/models`）：与 `baseUrl` 拼接使用
- **完整 URL**（如 `https://api.example.com/v4/models`）：直接作为请求地址

当 `modelsEndpoint` 为空时，默认使用 `${baseUrl}/models`。

## 变更内容

| 文件 | 改动 |
|------|------|
| `src/utils/compatibleModelManager.ts` | `CompatibleModelConfig` 接口新增 `modelsEndpoint` 可选字段 |
| `src/providers/compatibleProvider.ts` | 透传 `modelsEndpoint` 到模型配置 |
| `src/ui/modelEditor.ts` | 新增 `resolveModelsUrl()` 方法，替换原有的 URL 拼接逻辑；`modelData` 中传递 `endpoint` 和 `modelsEndpoint` |
| `src/ui/modelEditor.js` | 新增 `endpoint`/`modelsEndpoint` 表单字段、输入校验与保存逻辑 |
| `src/utils/jsonSchemaProvider.ts` | 补充 `modelsEndpoint` 的 JSON Schema 定义，提供 `settings.json` 自动补全与校验 |

## 测试

- 已在本地编译并安装 VSIX 测试
- 自定义 `modelsEndpoint` 后可正常获取模型列表
- 自定义 `endpoint` 后可正常进行聊天请求
- 不配置 `modelsEndpoint` 时行为与原有逻辑一致（默认 `/models`）