### PR TITLE
feat(metrics): 实时展示首流延迟、输出耗时与流式速度

### DIFF
--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -385,8 +385,8 @@ export class AnthropicHandler {
         const completedServerToolCalls = new Map<string, { toolId?: string; name?: string; jsonInput?: string }>();
         let usage: Anthropic.Messages.Usage | undefined;
         let responseId: string | undefined;
-        // 记录流处理的开始时间（在 message_start 事件中设置）
-        let streamStartTime = Date.now();
+        // 记录流处理的开始时间（message_start 到达前为 undefined，避免使用进入函数的旧时间）
+        let streamStartTime: number | undefined;
         let streamEndTime: number | undefined = undefined;
 
         Logger.debug('Starting Anthropic stream response processing');
@@ -612,7 +612,10 @@ export class AnthropicHandler {
         // 记录流处理的结束时间
         streamEndTime ??= Date.now();
 
-        if (usage) {
+        // 补齐流开始时间：兼容网关可能未发送 message_start
+        streamStartTime ??= reporter.getMetricStreamStartTime();
+
+        if (usage && streamStartTime !== undefined) {
             const duration = streamEndTime - streamStartTime;
             const speed = duration > 0 ? ((usage.output_tokens / duration) * 1000).toFixed(1) : 'N/A';
             Logger.debug(

--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -301,12 +301,15 @@ export class AnthropicHandler {
                 requestStartTime,
                 onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
+            // 局部收窄：try 块内用 const 引用确保 TypeScript 知道非 undefined，
+            // 外层 let reporter 供 finally 兜底使用
+            const streamReporter = reporter;
 
             const stream = await client.messages.create(createParams, anthropicStreamOptions);
 
             // 使用完整的流处理函数
-            const result = await this.handleAnthropicStream(stream, reporter, token);
-            reporter.reportUsage(result?.usage);
+            const result = await this.handleAnthropicStream(stream, streamReporter, token);
+            streamReporter.reportUsage(result?.usage);
 
             Logger.info(`[${model.name}] Anthropic request completed`, result?.usage);
 
@@ -480,7 +483,9 @@ export class AnthropicHandler {
                             try {
                                 const parsedJson = JSON.parse(pendingToolCall.jsonInput);
                                 // JSON 解析成功，立即报告工具调用（countArgs: false，已通过 reportToolArgDelta 统计）
-                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, { countArgs: false });
+                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, {
+                                    countArgs: false
+                                });
                                 Logger.trace(
                                     `[${reporter.getModelName()}] Tool call completed: ${pendingToolCall.name}`
                                 );
@@ -491,8 +496,7 @@ export class AnthropicHandler {
                         } else if (chunk.delta.type === 'input_json_delta' && pendingServerToolCall) {
                             const partialJson = chunk.delta.partial_json ?? '';
                             const partialLen = partialJson.length;
-                            pendingServerToolCall.jsonInput =
-                                (pendingServerToolCall.jsonInput || '') + partialJson;
+                            pendingServerToolCall.jsonInput = (pendingServerToolCall.jsonInput || '') + partialJson;
                             // tool argument delta 是 provider 实际回传的一部分
                             reporter.reportToolArgDelta(partialLen);
                         } else if (chunk.delta.type === 'thinking_delta') {
@@ -537,7 +541,9 @@ export class AnthropicHandler {
                                     parsedJson = {};
                                 }
 
-                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, { countArgs: false });
+                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, {
+                                    countArgs: false
+                                });
                             } catch (e) {
                                 Logger.error(`Fallback tool call handling failed (${pendingToolCall.name}):`, e);
                             }

--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -469,13 +469,18 @@ export class AnthropicHandler {
                             reporter.reportText(chunk.delta.text);
                         } else if (chunk.delta.type === 'input_json_delta' && pendingToolCall) {
                             // 工具调用参数增量
-                            pendingToolCall.jsonInput = (pendingToolCall.jsonInput || '') + chunk.delta.partial_json;
+                            const partialJson = chunk.delta.partial_json ?? '';
+                            const partialLen = partialJson.length;
+                            pendingToolCall.jsonInput = (pendingToolCall.jsonInput || '') + partialJson;
+
+                            // tool argument delta 是 provider 实际回传的一部分，即使 Chat 面板隐藏也应计入 live chars/s
+                            reporter.reportToolArgDelta(partialLen);
 
                             // 尝试立即解析并报告工具调用（如果 JSON 已完整）
                             try {
                                 const parsedJson = JSON.parse(pendingToolCall.jsonInput);
-                                // JSON 解析成功，立即报告工具调用
-                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson);
+                                // JSON 解析成功，立即报告工具调用（countArgs: false，已通过 reportToolArgDelta 统计）
+                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, { countArgs: false });
                                 Logger.trace(
                                     `[${reporter.getModelName()}] Tool call completed: ${pendingToolCall.name}`
                                 );
@@ -484,8 +489,12 @@ export class AnthropicHandler {
                                 // JSON 还不完整，继续累积
                             }
                         } else if (chunk.delta.type === 'input_json_delta' && pendingServerToolCall) {
+                            const partialJson = chunk.delta.partial_json ?? '';
+                            const partialLen = partialJson.length;
                             pendingServerToolCall.jsonInput =
-                                (pendingServerToolCall.jsonInput || '') + chunk.delta.partial_json;
+                                (pendingServerToolCall.jsonInput || '') + partialJson;
+                            // tool argument delta 是 provider 实际回传的一部分
+                            reporter.reportToolArgDelta(partialLen);
                         } else if (chunk.delta.type === 'thinking_delta') {
                             // 思考内容增量
                             const thinkingDelta = chunk.delta.thinking || '';
@@ -528,7 +537,7 @@ export class AnthropicHandler {
                                     parsedJson = {};
                                 }
 
-                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson);
+                                reporter.reportToolCall(pendingToolCall.toolId!, pendingToolCall.name!, parsedJson, { countArgs: false });
                             } catch (e) {
                                 Logger.error(`Fallback tool call handling failed (${pendingToolCall.name}):`, e);
                             }

--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -393,7 +393,7 @@ export class AnthropicHandler {
 
         try {
             for await (const chunk of stream) {
-                // 心跳：触发轻量刷新（不固定首令延迟）
+                // 心跳：触发轻量刷新（不固定首流延迟）
                 reporter.heartbeat();
 
                 if (token.isCancellationRequested) {
@@ -404,7 +404,7 @@ export class AnthropicHandler {
 
                 switch (chunk.type) {
                     case 'message_start': {
-                        // 消息开始 - 记录流开始时间，同时固定首令延迟（共用时间戳）
+                        // 消息开始 - 记录流开始时间，同时固定首流延迟（共用时间戳）
                         const now = Date.now();
                         streamStartTime = now;
                         reporter.markStreamStarted(now);

--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -18,6 +18,7 @@ import { t } from '../utils/l10n';
 import type { ModelChatResponseOptions, ModelConfig, ProviderConfig } from '../types/sharedTypes';
 import { OpenAIHandler } from './openaiHandler';
 import { StreamReporter } from './streamReporter';
+import * as liveMetrics from '../metrics/liveMetrics';
 import type { GenericModelProvider } from '../providers/genericModelProvider';
 import { isSubRequest, type RequestKind } from './requestClassifier';
 
@@ -186,11 +187,14 @@ export class AnthropicHandler {
         progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
         requestId: string,
         sessionId: string,
-        token: vscode.CancellationToken
+        token: vscode.CancellationToken,
+        requestStartTime?: number
     ): Promise<void> {
         // 将 vscode.CancellationToken 转换为 AbortSignal
         const abortController = new AbortController();
         const cancellationListener = token.onCancellationRequested(() => abortController.abort());
+
+        let reporter: StreamReporter | undefined;
 
         try {
             const client = await this.createAnthropicClient(modelConfig);
@@ -285,17 +289,20 @@ export class AnthropicHandler {
                 anthropicStreamOptions.headers = createOpenCodeHeaders(requestId, sessionId);
             }
 
-            const stream = await client.messages.create(createParams, anthropicStreamOptions);
-
-            // 创建统一的流报告器
-            const reporter = new StreamReporter({
+            // 提前创建 reporter，使首令延迟从请求发出后就开始滚动
+            reporter = new StreamReporter({
                 modelName: model.name,
                 modelId: model.id,
                 provider: this.provider,
                 sdkMode: 'anthropic',
                 progress,
-                sessionId
+                sessionId,
+                requestId,
+                requestStartTime,
+                onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
+
+            const stream = await client.messages.create(createParams, anthropicStreamOptions);
 
             // 使用完整的流处理函数
             const result = await this.handleAnthropicStream(stream, reporter, token);
@@ -349,6 +356,7 @@ export class AnthropicHandler {
             // progress.report(new vscode.LanguageModelTextPart(errorMessage));
             throw error;
         } finally {
+            reporter?.finishMetrics();
             cancellationListener.dispose();
         }
     }
@@ -381,6 +389,9 @@ export class AnthropicHandler {
 
         try {
             for await (const chunk of stream) {
+                // 心跳：触发轻量刷新（不固定首令延迟）
+                reporter.heartbeat();
+
                 if (token.isCancellationRequested) {
                     Logger.debug('Stream processing cancelled');
                     reporter.flushAll(null);
@@ -388,9 +399,11 @@ export class AnthropicHandler {
                 }
 
                 switch (chunk.type) {
-                    case 'message_start':
-                        // 消息开始 - 记录流开始时间
-                        streamStartTime = Date.now();
+                    case 'message_start': {
+                        // 消息开始 - 记录流开始时间，同时固定首令延迟（共用时间戳）
+                        const now = Date.now();
+                        streamStartTime = now;
+                        reporter.markStreamStarted(now);
                         // 收集初始使用统计
                         if (chunk.message.usage) {
                             usage = chunk.message.usage;
@@ -402,6 +415,7 @@ export class AnthropicHandler {
                             Logger.debug(`Received Anthropic message id (responseId): ${responseId}`);
                         }
                         break;
+                    }
 
                     case 'content_block_start':
                         // 内容块开始

--- a/src/handlers/anthropicHandler.ts
+++ b/src/handlers/anthropicHandler.ts
@@ -289,7 +289,8 @@ export class AnthropicHandler {
                 anthropicStreamOptions.headers = createOpenCodeHeaders(requestId, sessionId);
             }
 
-            // 提前创建 reporter，使首令延迟从请求发出后就开始滚动
+            // 提前创建 reporter，使实时 TTFT 从 provider 请求处理起点开始滚动；
+            // 该起点不等同于严格的网络请求发出时刻。
             reporter = new StreamReporter({
                 modelName: model.name,
                 modelId: model.id,

--- a/src/handlers/geminiHandler.ts
+++ b/src/handlers/geminiHandler.ts
@@ -19,6 +19,7 @@ import type { GenericUsageData, RawUsageData } from '../usages/fileLogger/types'
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { convertMessagesToGemini, convertToolsToGemini } from './geminiConverter';
 import { StreamReporter } from './streamReporter';
+import * as liveMetrics from '../metrics/liveMetrics';
 import type { GenericModelProvider } from '../providers/genericModelProvider';
 import type {
     GeminiGenerationConfig,
@@ -505,7 +506,8 @@ export class GeminiHandler {
         progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
         requestId: string,
         sessionId: string,
-        token: vscode.CancellationToken
+        token: vscode.CancellationToken,
+        requestStartTime?: number
     ): Promise<void> {
         // 确保 Gemini CLI 版本号已加载（首次调用时会执行 `gemini --version`，后续调用返回缓存）。
         await GeminiHandler.ensureCliVersionLoaded();
@@ -592,6 +594,9 @@ export class GeminiHandler {
 
         Logger.info(`🚀 ${model.name} Sending ${this.displayName} Gemini HTTP request (model=${modelId})`);
 
+        // 创建统一的流报告器
+        let reporter: StreamReporter | undefined;
+
         try {
             // 用途：构建第三方 Gemini 网关可用的流式 SSE endpoint。
             const endpoint = this.buildEndpoint(normalizedBaseUrl, modelId, true);
@@ -604,14 +609,16 @@ export class GeminiHandler {
                 );
             }
 
-            // 创建统一的流报告器
-            const reporter = new StreamReporter({
+            reporter = new StreamReporter({
                 modelName: model.name,
                 modelId: model.id,
                 provider: this.provider,
                 sdkMode: 'gemini',
                 progress,
-                sessionId
+                sessionId,
+                requestId,
+                requestStartTime,
+                onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
 
             // 用途：执行 fetch 请求
@@ -660,6 +667,7 @@ export class GeminiHandler {
 
             throw error;
         } finally {
+            reporter?.finishMetrics();
             cancelSub.dispose();
         }
     }
@@ -693,8 +701,11 @@ export class GeminiHandler {
         // 关键兼容点：
         // - 标准 SSE：`data: {json}` 或 `data: [DONE]`
         // - 类 SSE/网关实现：可能直接输出 JSON 行（不带 data:）
-        // - 这里按“行”解析，因此若网关把 JSON 拆成多行，仍可能需要后续增强（目前按现有兼容策略）。
+        // - 这里按”行”解析，因此若网关把 JSON 拆成多行，仍可能需要后续增强（目前按现有兼容策略）。
         const processRawLine = (rawLine: string): void => {
+            // 心跳：每次收到 SSE 数据时触发，确保”正在考虑”状态下也能更新耗时
+            reporter.heartbeat();
+
             const line = rawLine.trim();
             if (!line) {
                 return;
@@ -715,9 +726,11 @@ export class GeminiHandler {
                 return;
             }
 
-            // 记录首次接收有效数据的时间
+            // 记录首次接收有效数据的时间，同时固定首令延迟（共用时间戳）
             if (streamStartTime === undefined) {
-                streamStartTime = Date.now();
+                const now = Date.now();
+                streamStartTime = now;
+                reporter.markStreamStarted(now);
             }
 
             // 兼容 Code Assist 包装：可能是 { response: GenerateContentResponse }。

--- a/src/handlers/geminiHandler.ts
+++ b/src/handlers/geminiHandler.ts
@@ -726,7 +726,7 @@ export class GeminiHandler {
                 return;
             }
 
-            // 记录首次接收有效数据的时间，同时固定首令延迟（共用时间戳）
+            // 记录首次接收有效数据的时间，同时固定首流延迟（共用时间戳）
             if (streamStartTime === undefined) {
                 const now = Date.now();
                 streamStartTime = now;

--- a/src/handlers/openaiCustomHandler.ts
+++ b/src/handlers/openaiCustomHandler.ts
@@ -291,14 +291,8 @@ export class OpenAICustomHandler {
                     break;
                 }
 
-                // 记录首个 raw chunk 的时间作为流开始时间，同时固定首令延迟（共用时间戳，保持与原统计口径一致）
-                if (streamStartTime === undefined) {
-                    const now = Date.now();
-                    streamStartTime = now;
-                    reporter.markStreamStarted(now);
-                }
-
                 // 心跳：触发轻量刷新（不固定首令延迟）
+                // markStreamStarted 移到有效 JSON 解析后，避免 heartbeat/空行/非 JSON 噪声提前固定 TTFT
                 reporter.heartbeat();
 
                 buffer += decoder.decode(value, { stream: true });
@@ -322,6 +316,13 @@ export class OpenAICustomHandler {
                         try {
                             const chunk = JSON.parse(data);
                             chunkCount++;
+
+                            // 首个有效 JSON chunk 到达时固定首流时间（与 Gemini handler 口径对齐）
+                            if (streamStartTime === undefined) {
+                                const now = Date.now();
+                                streamStartTime = now;
+                                reporter.markStreamStarted(now);
+                            }
 
                             // 提取响应 ID（从首个 chunk）
                             if (chunk.id && typeof chunk.id === 'string') {

--- a/src/handlers/openaiCustomHandler.ts
+++ b/src/handlers/openaiCustomHandler.ts
@@ -11,6 +11,7 @@ import { ApiKeyManager } from '../utils/apiKeyManager';
 import { TokenUsagesManager } from '../usages/usagesManager';
 import { ModelConfig, ProviderConfig } from '../types/sharedTypes';
 import { StreamReporter } from './streamReporter';
+import * as liveMetrics from '../metrics/liveMetrics';
 import { t } from '../utils/l10n';
 import type { GenericModelProvider } from '../providers/genericModelProvider';
 
@@ -122,7 +123,8 @@ export class OpenAICustomHandler {
         progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
         requestId: string,
         sessionId: string,
-        token: vscode.CancellationToken
+        token: vscode.CancellationToken,
+        requestStartTime?: number
     ): Promise<void> {
         const provider = modelConfig.provider || this.provider;
         const apiKey = await ApiKeyManager.getApiKey(provider);
@@ -156,7 +158,22 @@ export class OpenAICustomHandler {
         const abortController = new AbortController();
         const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 
+        // 提前创建 reporter，使首令延迟从请求发出后就开始滚动
+        let reporter: StreamReporter | undefined;
+
         try {
+            reporter = new StreamReporter({
+                modelName: model.name,
+                modelId: model.id,
+                provider: this.provider,
+                sdkMode: 'openai',
+                progress,
+                sessionId,
+                requestId,
+                requestStartTime,
+                onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
+            });
+
             // 合并提供商级别和模型级别的 customHeader
             // 模型级别的 customHeader 会覆盖提供商级别的同名头部
             const mergedCustomHeader = {
@@ -220,16 +237,6 @@ export class OpenAICustomHandler {
                 throw new Error(t('Response body is empty', '响应体为空'));
             }
 
-            // 创建统一的流报告器
-            const reporter = new StreamReporter({
-                modelName: model.name,
-                modelId: model.id,
-                provider: this.provider,
-                sdkMode: 'openai',
-                progress,
-                sessionId
-            });
-
             await this.processStream(
                 model,
                 response.body as ReadableStream<Uint8Array>,
@@ -246,6 +253,7 @@ export class OpenAICustomHandler {
             }
             throw error;
         } finally {
+            reporter?.finishMetrics();
             cancellationListener.dispose();
         }
     }
@@ -282,10 +290,15 @@ export class OpenAICustomHandler {
                     break;
                 }
 
-                // 记录首个 chunk 的时间作为流开始时间
+                // 记录首个 raw chunk 的时间作为流开始时间，同时固定首令延迟（共用时间戳，保持与原统计口径一致）
                 if (streamStartTime === undefined) {
-                    streamStartTime = Date.now();
+                    const now = Date.now();
+                    streamStartTime = now;
+                    reporter.markStreamStarted(now);
                 }
+
+                // 心跳：触发轻量刷新（不固定首令延迟）
+                reporter.heartbeat();
 
                 buffer += decoder.decode(value, { stream: true });
                 const lines = buffer.split('\n');

--- a/src/handlers/openaiCustomHandler.ts
+++ b/src/handlers/openaiCustomHandler.ts
@@ -158,7 +158,8 @@ export class OpenAICustomHandler {
         const abortController = new AbortController();
         const cancellationListener = token.onCancellationRequested(() => abortController.abort());
 
-        // 提前创建 reporter，使首令延迟从请求发出后就开始滚动
+        // 提前创建 reporter，使实时 TTFT 从 provider 请求处理起点开始滚动；
+        // 该起点不等同于严格的网络请求发出时刻。
         let reporter: StreamReporter | undefined;
 
         try {

--- a/src/handlers/openaiCustomHandler.ts
+++ b/src/handlers/openaiCustomHandler.ts
@@ -291,7 +291,7 @@ export class OpenAICustomHandler {
                     break;
                 }
 
-                // 心跳：触发轻量刷新（不固定首令延迟）
+                // 心跳：触发轻量刷新（不固定首流延迟）
                 // markStreamStarted 移到有效 JSON 解析后，避免 heartbeat/空行/非 JSON 噪声提前固定 TTFT
                 reporter.heartbeat();
 

--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -12,6 +12,7 @@ import { t } from '../utils/l10n';
 import { TokenUsagesManager } from '../usages/usagesManager';
 import { ModelChatResponseOptions, ModelConfig, ProviderConfig } from '../types/sharedTypes';
 import { StreamReporter } from './streamReporter';
+import * as liveMetrics from '../metrics/liveMetrics';
 import { getReasoningReplayPolicy, shouldInjectReasoningPlaceholder } from './reasoningReplayPolicy';
 import { decodeStatefulMarker } from './statefulMarker';
 import { CustomDataPartMimeTypes } from './types';
@@ -888,11 +889,14 @@ export class OpenAIHandler {
         progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
         requestId: string,
         sessionId: string,
-        token: vscode.CancellationToken
+        token: vscode.CancellationToken,
+        requestStartTime?: number
     ): Promise<void> {
         Logger.debug(`${model.name} starting ${this.displayName} request handling`);
         // 清理当前请求的事件去重跟踪器
         this.currentRequestProcessedEvents.clear();
+
+        let reporter: StreamReporter | undefined;
 
         try {
             const client = await this.createOpenAIClient(modelConfig);
@@ -903,13 +907,16 @@ export class OpenAIHandler {
             Logger.info(`🚀 ${model.name} Sending ${this.displayName} request`);
 
             // 创建统一的流报告器
-            const reporter = new StreamReporter({
+            reporter = new StreamReporter({
                 modelName: model.name,
                 modelId: model.id,
                 provider: this.provider,
                 sdkMode: 'openai',
                 progress,
-                sessionId
+                sessionId,
+                requestId,
+                requestStartTime,
+                onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
 
             // 使用 OpenAI SDK 的事件驱动流式方法，利用内置工具调用处理
@@ -934,10 +941,15 @@ export class OpenAIHandler {
                 // 利用 SDK 内置的事件系统处理工具调用和内容
                 stream
                     .on('chunk', (chunk, _snapshot: unknown) => {
-                        // 记录首个 chunk 的时间作为流开始时间
+                        // 记录首个 chunk 的时间作为流开始时间，同时固定首令延迟（共用时间戳）
                         if (streamStartTime === undefined) {
-                            streamStartTime = Date.now();
+                            const now = Date.now();
+                            streamStartTime = now;
+                            reporter.markStreamStarted(now);
                         }
+
+                        // 心跳：触发轻量刷新（不固定首令延迟）
+                        reporter.heartbeat();
 
                         // 处理token使用统计：仅保存到 finalUsage，最后再统一输出
                         if (chunk.usage) {
@@ -1159,6 +1171,8 @@ export class OpenAIHandler {
                 // 其他错误类型
                 throw error;
             }
+        } finally {
+            reporter?.finishMetrics();
         }
     }
 

--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -918,6 +918,9 @@ export class OpenAIHandler {
                 requestStartTime,
                 onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
+            // 局部收窄：try 块内用 const 引用确保 TypeScript 知道非 undefined，
+            // 外层 let reporter 供 finally 兜底使用
+            const streamReporter = reporter;
 
             // 使用 OpenAI SDK 的事件驱动流式方法，利用内置工具调用处理
             // 将 vscode.CancellationToken 转换为 AbortSignal
@@ -945,11 +948,11 @@ export class OpenAIHandler {
                         if (streamStartTime === undefined) {
                             const now = Date.now();
                             streamStartTime = now;
-                            reporter.markStreamStarted(now);
+                            streamReporter.markStreamStarted(now);
                         }
 
                         // 心跳：触发轻量刷新（不固定首令延迟）
-                        reporter.heartbeat();
+                        streamReporter.heartbeat();
 
                         // 处理token使用统计：仅保存到 finalUsage，最后再统一输出
                         if (chunk.usage) {
@@ -970,7 +973,7 @@ export class OpenAIHandler {
                                 if (delta?.tool_calls && delta.tool_calls.length > 0) {
                                     for (const toolCall of delta.tool_calls) {
                                         const toolIndex = toolCall.index ?? 0;
-                                        reporter.accumulateToolCall(
+                                        streamReporter.accumulateToolCall(
                                             toolIndex,
                                             toolCall.id,
                                             toolCall.function?.name,
@@ -986,25 +989,25 @@ export class OpenAIHandler {
                                     message?.reasoning_content ??
                                     message?.reasoning;
                                 if (reasoningContent) {
-                                    reporter.bufferThinking(reasoningContent);
+                                    streamReporter.bufferThinking(reasoningContent);
                                 } else {
                                     // reasoning_details 作为 fallback，仅在主源为空时使用，避免重复
                                     const detailsContent = extractReasoningDetailsText(delta?.reasoning_details);
                                     if (detailsContent) {
-                                        reporter.bufferThinking(detailsContent);
+                                        streamReporter.bufferThinking(detailsContent);
                                     }
                                 }
 
                                 // 检查同一个 chunk 中是否有 delta.content（文本内容）
                                 const deltaContent = delta?.content;
                                 if (deltaContent && typeof deltaContent === 'string') {
-                                    reporter.reportText(deltaContent);
+                                    streamReporter.reportText(deltaContent);
                                 }
 
                                 // 另外兼容：如果服务端把最终文本放在 message.content（旧/混合格式），当作 content 增量处理
                                 const messageContent = message?.content;
                                 if (typeof messageContent === 'string' && messageContent.length > 0) {
-                                    reporter.reportText(messageContent);
+                                    streamReporter.reportText(messageContent);
                                 }
                             }
                         }
@@ -1021,14 +1024,14 @@ export class OpenAIHandler {
                 streamEndTime = Date.now();
 
                 // 流结束，输出所有剩余内容
-                reporter.flushAll(null);
+                streamReporter.flushAll(null);
 
                 // 检查是否有流错误
                 if (streamError) {
                     throw streamError;
                 }
 
-                reporter.reportUsage(finalUsage);
+                streamReporter.reportUsage(finalUsage);
 
                 // 计算并记录输出速度
                 const usageData = finalUsage as OpenAI.Completions.CompletionUsage | undefined;

--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -944,14 +944,14 @@ export class OpenAIHandler {
                 // 利用 SDK 内置的事件系统处理工具调用和内容
                 stream
                     .on('chunk', (chunk, _snapshot: unknown) => {
-                        // 记录首个 chunk 的时间作为流开始时间，同时固定首令延迟（共用时间戳）
+                        // 记录首个 chunk 的时间作为流开始时间，同时固定首流延迟（共用时间戳）
                         if (streamStartTime === undefined) {
                             const now = Date.now();
                             streamStartTime = now;
                             streamReporter.markStreamStarted(now);
                         }
 
-                        // 心跳：触发轻量刷新（不固定首令延迟）
+                        // 心跳：触发轻量刷新（不固定首流延迟）
                         streamReporter.heartbeat();
 
                         // 处理token使用统计：仅保存到 finalUsage，最后再统一输出

--- a/src/handlers/openaiResponsesHandler.ts
+++ b/src/handlers/openaiResponsesHandler.ts
@@ -779,23 +779,31 @@ export class OpenAIResponsesHandler {
                         }
                     })
                     .on('response.function_call_arguments.delta', event => {
-                        // 累计工具参数增量到 live chars/s
+                        // Tool arguments delta only counts toward live chars/s when it can be mapped
+                        // to a stable output item (item_id). If a compatibility gateway omits item_id
+                        // and no stable index can be resolved, skip delta counting and let the
+                        // done/fallback path count the complete arguments once.
+                        // Prefer under-counting to double-counting.
                         if (token.isCancellationRequested) {
                             return;
                         }
+
                         const itemId = event.item_id;
                         const idx = itemId ? getToolCallIndex(itemId) : undefined;
-                        // 某些兼容网关可能在 output_item.added 已带完整 args 后又补发 delta，
-                        // 此时该 call 已 completed，跳过避免重复计数
-                        if (idx !== undefined && completedToolCallIndices.has(idx)) {
+                        if (idx === undefined) {
                             return;
                         }
+
+                        // 某些兼容网关可能在 output_item.added 已带完整 args 后又补发 delta，
+                        // 此时该 call 已 completed，跳过避免重复计数
+                        if (completedToolCallIndices.has(idx)) {
+                            return;
+                        }
+
                         const delta = typeof event.delta === 'string' ? event.delta : '';
                         if (delta.length > 0) {
                             streamReporter.reportToolArgDelta(delta.length);
-                            if (idx !== undefined) {
-                                deltaCountedToolCallIndices.add(idx);
-                            }
+                            deltaCountedToolCallIndices.add(idx);
                         }
                     })
                     .on('response.function_call_arguments.done', event => {

--- a/src/handlers/openaiResponsesHandler.ts
+++ b/src/handlers/openaiResponsesHandler.ts
@@ -13,6 +13,7 @@ import { OpenAIHandler } from './openaiHandler';
 import { getStatefulMarkerAndIndex } from './statefulMarker';
 import { StreamReporter } from './streamReporter';
 import { isSubRequest, type RequestKind } from './requestClassifier';
+import * as liveMetrics from '../metrics/liveMetrics';
 import { CliAuthFactory } from '../cli/auth/cliAuthFactory';
 import { CodexCliAuth } from '../cli/auth/codexCliAuth';
 import type { GenericModelProvider } from '../providers/genericModelProvider';
@@ -378,22 +379,28 @@ export class OpenAIResponsesHandler {
         progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
         requestId: string,
         sessionId: string,
-        token: vscode.CancellationToken
+        token: vscode.CancellationToken,
+        requestStartTime?: number
     ): Promise<void> {
         Logger.debug(`${model.name} starting ${this.displayName} Responses API request handling`);
+
+        let reporter: StreamReporter | undefined;
 
         try {
             const client = await this.handler.createOpenAIClient(modelConfig);
             Logger.info(`🚀 ${model.name} Sending ${this.displayName} Responses API request`);
 
             // 创建统一的流报告器
-            const reporter = new StreamReporter({
+            reporter = new StreamReporter({
                 modelName: model.name,
                 modelId: model.id,
                 provider: this.providerKey,
                 sdkMode: 'openai-responses',
                 progress,
-                sessionId
+                sessionId,
+                requestId,
+                requestStartTime,
+                onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
 
             const requestModel = modelConfig.model || modelConfig.id;
@@ -638,8 +645,10 @@ export class OpenAIResponsesHandler {
                 // 使用 on(event) 模式处理流事件
                 stream
                     .on('response.created', () => {
-                        // 响应开始事件 - 记录流开始时间
-                        streamStartTime = Date.now();
+                        // 响应开始事件 - 记录流开始时间，同时固定首令延迟（共用时间戳）
+                        const now = Date.now();
+                        streamStartTime = now;
+                        reporter.markStreamStarted(now);
                     })
                     .on('response.output_text.delta', event => {
                         if (token.isCancellationRequested) {
@@ -1092,6 +1101,8 @@ export class OpenAIResponsesHandler {
             } else {
                 throw error;
             }
+        } finally {
+            reporter?.finishMetrics();
         }
     }
 }

--- a/src/handlers/openaiResponsesHandler.ts
+++ b/src/handlers/openaiResponsesHandler.ts
@@ -402,6 +402,9 @@ export class OpenAIResponsesHandler {
                 requestStartTime,
                 onLiveMetrics: event => liveMetrics.emitLiveMetrics(event)
             });
+            // 局部收窄：try 块内用 const 引用确保 TypeScript 知道非 undefined，
+            // 外层 let reporter 供 finally 兜底使用
+            const streamReporter = reporter;
 
             const requestModel = modelConfig.model || modelConfig.id;
 
@@ -438,6 +441,8 @@ export class OpenAIResponsesHandler {
             // 工具调用缓冲区 - 使用索引跟踪，支持累积
             const toolCallBuffers = new Map<number, { id: string; name: string; args: string }>();
             const completedToolCallIndices = new Set<number>();
+            // 追踪已通过 delta 计数的工具调用，避免 done/fallback 重复统计
+            const deltaCountedToolCallIndices = new Set<number>();
             const toolCallIdToIndex = new Map<string, number>();
             let nextToolCallIndex = 0;
 
@@ -648,7 +653,7 @@ export class OpenAIResponsesHandler {
                         // 响应开始事件 - 记录流开始时间，同时固定首令延迟（共用时间戳）
                         const now = Date.now();
                         streamStartTime = now;
-                        reporter.markStreamStarted(now);
+                        streamReporter.markStreamStarted(now);
                     })
                     .on('response.output_text.delta', event => {
                         if (token.isCancellationRequested) {
@@ -661,7 +666,7 @@ export class OpenAIResponsesHandler {
                         }
                         const delta = event.delta;
                         if (delta && typeof delta === 'string') {
-                            reporter.reportText(delta);
+                            streamReporter.reportText(delta);
                         }
                     })
                     .on('response.output_text.done', event => {
@@ -672,7 +677,7 @@ export class OpenAIResponsesHandler {
                         }
                         const text = event.text || '';
                         if (text) {
-                            reporter.reportText(text);
+                            streamReporter.reportText(text);
                         }
                     })
                     .on('response.refusal.delta', event => {
@@ -687,7 +692,7 @@ export class OpenAIResponsesHandler {
                         }
                         const delta = event.delta;
                         if (delta && typeof delta === 'string') {
-                            reporter.reportText(delta);
+                            streamReporter.reportText(delta);
                         }
                     })
                     .on('response.refusal.done', event => {
@@ -701,7 +706,7 @@ export class OpenAIResponsesHandler {
                         }
                         const refusal = event.refusal || '';
                         if (refusal) {
-                            reporter.reportText(refusal);
+                            streamReporter.reportText(refusal);
                         }
                     })
                     .on('response.reasoning_text.delta', event => {
@@ -716,7 +721,7 @@ export class OpenAIResponsesHandler {
                         }
                         const delta = event.delta;
                         if (delta && typeof delta === 'string') {
-                            reporter.bufferThinking(delta);
+                            streamReporter.bufferThinking(delta);
                         }
                     })
                     .on('response.reasoning_text.done', event => {
@@ -727,10 +732,10 @@ export class OpenAIResponsesHandler {
                         const eventKey = getContentEventKey(event.item_id, event.content_index);
                         // 某些网关只发送最终的 done 事件（没有增量）
                         if ((!eventKey || !reasoningTextDeltaKeys.has(eventKey)) && event.text) {
-                            reporter.bufferThinking(event.text);
+                            streamReporter.bufferThinking(event.text);
                         }
-                        reporter.flushThinking('reasoning_text 完成');
-                        reporter.endThinkingChain();
+                        streamReporter.flushThinking('reasoning_text 完成');
+                        streamReporter.endThinkingChain();
                     })
                     .on('response.reasoning_summary_text.delta', event => {
                         // 处理思维链摘要增量（与官方实现一致：记录展示过摘要防止重复）
@@ -747,7 +752,7 @@ export class OpenAIResponsesHandler {
                         }
                         const delta = event.delta;
                         if (delta && typeof delta === 'string') {
-                            reporter.bufferThinking(delta);
+                            streamReporter.bufferThinking(delta);
                         }
                     })
                     .on('response.reasoning_summary_text.done', event => {
@@ -761,10 +766,10 @@ export class OpenAIResponsesHandler {
                         }
                         // 某些网关只发送最终的 done 事件（没有增量）
                         if ((!eventKey || !reasoningSummaryDeltaKeys.has(eventKey)) && event.text) {
-                            reporter.bufferThinking(event.text);
+                            streamReporter.bufferThinking(event.text);
                         }
-                        reporter.flushThinking('reasoning_summary 完成');
-                        reporter.endThinkingChain();
+                        streamReporter.flushThinking('reasoning_summary 完成');
+                        streamReporter.endThinkingChain();
                     })
                     .on('response.reasoning_summary_part.done', event => {
                         // 推理摘要 part 完成（与官方实现对齐）
@@ -773,10 +778,24 @@ export class OpenAIResponsesHandler {
                             reasoningSummaryItemIds.add(event.item_id);
                         }
                     })
-                    .on('response.function_call_arguments.delta', () => {
-                        // SDK 会在 done 事件中提供完整的 arguments，这里不需要处理
+                    .on('response.function_call_arguments.delta', event => {
+                        // 累计工具参数增量到 live chars/s
                         if (token.isCancellationRequested) {
                             return;
+                        }
+                        const itemId = event.item_id;
+                        const idx = itemId ? getToolCallIndex(itemId) : undefined;
+                        // 某些兼容网关可能在 output_item.added 已带完整 args 后又补发 delta，
+                        // 此时该 call 已 completed，跳过避免重复计数
+                        if (idx !== undefined && completedToolCallIndices.has(idx)) {
+                            return;
+                        }
+                        const delta = typeof event.delta === 'string' ? event.delta : '';
+                        if (delta.length > 0) {
+                            streamReporter.reportToolArgDelta(delta.length);
+                            if (idx !== undefined) {
+                                deltaCountedToolCallIndices.add(idx);
+                            }
                         }
                     })
                     .on('response.function_call_arguments.done', event => {
@@ -811,7 +830,10 @@ export class OpenAIResponsesHandler {
                         // 尝试发送工具调用
                         try {
                             const input = JSON.parse(args || '{}');
-                            reporter.reportToolCall(callId, name, input);
+                            // delta 已逐步计数时跳过 args 字符统计，避免重复计入
+                            streamReporter.reportToolCall(callId, name, input, {
+                                countArgs: !deltaCountedToolCallIndices.has(idx)
+                            });
                             completedToolCallIndices.add(idx);
                         } catch (e) {
                             Logger.warn(`Failed to parse tool call arguments: ${args}`, e);
@@ -864,7 +886,9 @@ export class OpenAIResponsesHandler {
                             if (args && name) {
                                 try {
                                     const input = JSON.parse(args);
-                                    reporter.reportToolCall(callId, name, input);
+                                    streamReporter.reportToolCall(callId, name, input, {
+                                        countArgs: !deltaCountedToolCallIndices.has(idx)
+                                    });
                                     completedToolCallIndices.add(idx);
                                 } catch (e) {
                                     Logger.warn(`Failed to parse tool call arguments: ${args}`, e);
@@ -889,7 +913,7 @@ export class OpenAIResponsesHandler {
                                     reasoningItem.id && reasoningSummaryItemIds.has(reasoningItem.id) ?
                                         undefined
                                     :   reasoningItem.summary?.map(s => s.text);
-                                reporter.reportEncryptedThinking(
+                                streamReporter.reportEncryptedThinking(
                                     reasoningItem.encrypted_content,
                                     reasoningItem.id,
                                     summaryText
@@ -915,7 +939,9 @@ export class OpenAIResponsesHandler {
 
                             try {
                                 const input = JSON.parse(args);
-                                reporter.reportToolCall(callId as string, name, input);
+                                streamReporter.reportToolCall(callId as string, name, input, {
+                                    countArgs: !deltaCountedToolCallIndices.has(idx)
+                                });
                                 completedToolCallIndices.add(idx);
                             } catch (e) {
                                 Logger.warn(`Failed to parse tool call arguments: ${args}`, e);
@@ -955,7 +981,9 @@ export class OpenAIResponsesHandler {
 
                                         try {
                                             const input = JSON.parse(item.arguments || '{}');
-                                            reporter.reportToolCall(callId, item.name, input);
+                                            streamReporter.reportToolCall(callId, item.name, input, {
+                                                countArgs: !deltaCountedToolCallIndices.has(idx)
+                                            });
                                             completedToolCallIndices.add(idx);
                                         } catch (e) {
                                             Logger.warn(`Failed to parse tool call arguments: ${item.arguments}`, e);
@@ -967,7 +995,7 @@ export class OpenAIResponsesHandler {
 
                         if (responseId) {
                             // 流结束，输出所有剩余内容和 StatefulMarker
-                            reporter.flushAll(null, {
+                            streamReporter.flushAll(null, {
                                 sessionId,
                                 responseId,
                                 expireAt: sessionExpireAt
@@ -976,7 +1004,7 @@ export class OpenAIResponsesHandler {
                                 `💾 ${model.name} Passed StatefulMarker: sessionId=${sessionId}, responseId=${responseId}`
                             );
                         } else {
-                            reporter.flushAll(null);
+                            streamReporter.flushAll(null);
                         }
                     })
                     .on('error', error => {
@@ -1003,7 +1031,7 @@ export class OpenAIResponsesHandler {
                     throw streamError;
                 }
 
-                reporter.reportUsage(finalUsage);
+                streamReporter.reportUsage(finalUsage);
 
                 // 报告 usage 信息
                 Logger.info(`📊 ${model.name} Responses API request completed`, finalUsage);

--- a/src/handlers/openaiResponsesHandler.ts
+++ b/src/handlers/openaiResponsesHandler.ts
@@ -413,8 +413,8 @@ export class OpenAIResponsesHandler {
             const cancellationListener = token.onCancellationRequested(() => abortController.abort());
             let streamError: Error | null = null;
             let finalUsage: Record<string, unknown> | undefined = undefined;
-            // 记录流处理的开始和结束时间
-            let streamStartTime = Date.now();
+            // 记录流处理的开始和结束时间（response.created 到达前为 undefined，避免使用进入函数的旧时间）
+            let streamStartTime: number | undefined;
             let streamEndTime: number | undefined = undefined;
 
             // Responses API 专属：按输出项追踪 delta/done 事件，避免跨 item 误去重导致后续文本被吞掉
@@ -920,7 +920,7 @@ export class OpenAIResponsesHandler {
                                 const summaryText =
                                     reasoningItem.id && reasoningSummaryItemIds.has(reasoningItem.id) ?
                                         undefined
-                                    :   reasoningItem.summary?.map(s => s.text);
+                                        : reasoningItem.summary?.map(s => s.text);
                                 streamReporter.reportEncryptedThinking(
                                     reasoningItem.encrypted_content,
                                     reasoningItem.id,
@@ -1043,6 +1043,9 @@ export class OpenAIResponsesHandler {
 
                 // 报告 usage 信息
                 Logger.info(`📊 ${model.name} Responses API request completed`, finalUsage);
+
+                // 补齐流开始时间：兼容网关可能未发送 response.created
+                streamStartTime ??= streamReporter.getMetricStreamStartTime();
 
                 if (requestId) {
                     try {

--- a/src/handlers/openaiResponsesHandler.ts
+++ b/src/handlers/openaiResponsesHandler.ts
@@ -650,7 +650,7 @@ export class OpenAIResponsesHandler {
                 // 使用 on(event) 模式处理流事件
                 stream
                     .on('response.created', () => {
-                        // 响应开始事件 - 记录流开始时间，同时固定首令延迟（共用时间戳）
+                        // 响应开始事件 - 记录流开始时间，同时固定首流延迟（共用时间戳）
                         const now = Date.now();
                         streamStartTime = now;
                         streamReporter.markStreamStarted(now);

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -81,7 +81,6 @@ export class StreamReporter {
     private streamEnded = false;
     private outputChars = 0;
     private lastCharsPerSecond = 0; // 仅在收到实际 provider 输出字符时更新
-    private lastOutputAt = 0; // 最后一次收到 provider 输出字符的时间（内部使用，不暴露给 WebView）
     private lastLiveUpdateAt = 0;
     private firstStreamTime = 0; // 首个流事件到达时间（与 handler 的 streamStartTime 对齐，共用时间戳）
     private fixedFirstChunkLatencyMs = 0; // 固定的首令延迟（首流事件后不再变化）
@@ -155,6 +154,14 @@ export class StreamReporter {
     }
 
     /**
+     * 获取 Reporter 已记录的流开始时间（只读，不触发指标事件）
+     * 供 handler 在缺少标准首流事件时回退使用
+     */
+    getMetricStreamStartTime(): number | undefined {
+        return this.firstStreamTime > 0 ? this.firstStreamTime : undefined;
+    }
+
+    /**
      * 发送流式速度更新
      * @param force 是否跳过 200ms 节流（供 finishMetrics 最后一帧使用）
      */
@@ -172,9 +179,6 @@ export class StreamReporter {
         const firstChunkLatencyMs =
             this.firstChunkEmitted ? this.fixedFirstChunkLatencyMs : Math.max(0, now - this.requestStartTime!);
 
-        // 输出耗时：从 firstStreamTime 开始计算（仅用于耗时显示，不参与速度计算）
-        const elapsedMs = this.firstStreamTime > 0 ? Math.max(0, now - this.firstStreamTime) : 0;
-
         // 输出速度：使用 updateOutputSpeed 中缓存的值，暂停期间不会衰减
         const charsPerSecond = this.lastCharsPerSecond;
 
@@ -187,7 +191,6 @@ export class StreamReporter {
             modelName: this.modelName,
             firstChunkLatencyMs,
             outputChars: this.outputChars,
-            elapsedMs,
             charsPerSecond
         });
         this.lastLiveUpdateAt = now;
@@ -348,10 +351,8 @@ export class StreamReporter {
         }
 
         this.outputChars += addedChars;
-        this.lastOutputAt = now;
 
         const elapsedMs = this.firstStreamTime > 0 ? Math.max(1, now - this.firstStreamTime) : 0;
-
         this.lastCharsPerSecond = elapsedMs > 0 && this.outputChars > 0 ? (this.outputChars / elapsedMs) * 1000 : 0;
 
         this.emitStreamingUpdate();

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -83,7 +83,7 @@ export class StreamReporter {
     private lastCharsPerSecond = 0; // 仅在收到实际 provider 输出字符时更新
     private lastLiveUpdateAt = 0;
     private firstStreamTime = 0; // 首个流事件到达时间（与 handler 的 streamStartTime 对齐，共用时间戳）
-    private fixedFirstChunkLatencyMs = 0; // 固定的首令延迟（首流事件后不再变化）
+    private fixedFirstChunkLatencyMs = 0; // 固定的首流延迟（首流事件后不再变化）
     private readonly LIVE_UPDATE_INTERVAL = 200; // 200ms 节流间隔
 
     private readonly textBuffer = new TextBuffer();
@@ -175,7 +175,7 @@ export class StreamReporter {
             return;
         }
 
-        // 首令延迟：已收到首流事件则使用固定值，否则从请求开始持续计时
+        // 首流延迟：已收到首流事件则使用固定值，否则从请求开始持续计时
         const firstChunkLatencyMs =
             this.firstChunkEmitted ? this.fixedFirstChunkLatencyMs : Math.max(0, now - this.requestStartTime!);
 

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -339,10 +339,18 @@ export class StreamReporter {
             return;
         }
 
-        this.outputChars += addedChars;
-        this.lastOutputAt = Date.now();
+        const now = Date.now();
 
-        const elapsedMs = this.firstStreamTime > 0 ? Math.max(1, this.lastOutputAt - this.firstStreamTime) : 0;
+        // 兼容 Responses / 第三方网关缺少 response.created / 首流事件的情况：
+        // 只有真实输出字符到达时才兜底固定首流时间；不在 heartbeat 中固定（避免 ping/空 chunk 过早固定）
+        if (!this.firstChunkEmitted && this.canEmitMetrics()) {
+            this.markStreamStarted(now);
+        }
+
+        this.outputChars += addedChars;
+        this.lastOutputAt = now;
+
+        const elapsedMs = this.firstStreamTime > 0 ? Math.max(1, now - this.firstStreamTime) : 0;
 
         this.lastCharsPerSecond = elapsedMs > 0 && this.outputChars > 0 ? (this.outputChars / elapsedMs) * 1000 : 0;
 

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -80,6 +80,8 @@ export class StreamReporter {
     private firstChunkEmitted = false;
     private streamEnded = false;
     private outputChars = 0;
+    private lastCharsPerSecond = 0;  // 仅在收到实际 provider 输出字符时更新
+    private lastOutputAt = 0;        // 最后一次收到 provider 输出字符的时间（内部使用，不暴露给 WebView）
     private lastLiveUpdateAt = 0;
     private firstStreamTime = 0; // 首个流事件到达时间（与 handler 的 streamStartTime 对齐，共用时间戳）
     private fixedFirstChunkLatencyMs = 0; // 固定的首令延迟（首流事件后不再变化）
@@ -164,15 +166,13 @@ export class StreamReporter {
             ? this.fixedFirstChunkLatencyMs
             : Math.max(0, now - this.requestStartTime!);
 
-        // 输出耗时：从 firstStreamTime 开始计算
+        // 输出耗时：从 firstStreamTime 开始计算（仅用于耗时显示，不参与速度计算）
         const elapsedMs = this.firstStreamTime > 0
             ? Math.max(0, now - this.firstStreamTime)
             : 0;
 
-        // 输出速度：实时重算，长暂停期间会自然下降
-        const charsPerSecond = elapsedMs > 0 && this.outputChars > 0
-            ? (this.outputChars / elapsedMs) * 1000
-            : 0;
+        // 输出速度：使用 updateOutputSpeed 中缓存的值，暂停期间不会衰减
+        const charsPerSecond = this.lastCharsPerSecond;
 
         this.onLiveMetrics!({
             type: 'streamingUpdate',
@@ -242,9 +242,23 @@ export class StreamReporter {
 
     /**
      * 直接报告完整的工具调用（用于返回完整 tool call 的场景）
+     * @param options.countArgs 是否统计 args 字符到 live chars/s（默认 true）
+     *   Anthropic handler 因已通过 reportToolArgDelta 统计，应传 false 避免双计数
      */
-    reportToolCall(callId: string, name: string, args: Record<string, unknown> | object): void {
+    reportToolCall(
+        callId: string,
+        name: string,
+        args: Record<string, unknown> | object,
+        options: { countArgs?: boolean } = {}
+    ): void {
         this.prepareForToolCall();
+
+        // 完整 tool arguments 也是 provider 实际回传的一部分；
+        // 用于不提供 argument delta、只提供完整 tool call 的 provider/SDK 路径。
+        if (options.countArgs ?? true) {
+            this.updateOutputSpeed(this.getToolArgsLength(args));
+        }
+
         this.progress.report(new vscode.LanguageModelToolCallPart(callId, name, args));
         this.hasReceivedContent = true;
         this.hasToolCalls = true;
@@ -263,6 +277,26 @@ export class StreamReporter {
         const parts = typeof content === 'string' ? [new vscode.LanguageModelTextPart(content)] : content;
         this.progress.report(new vscode.LanguageModelToolResultPart(callId, parts));
         this.hasReceivedContent = true;
+    }
+
+    /**
+     * 上报工具调用参数增量字符数（仅更新速度统计，不触发 progress.report）
+     * 适用于 handler 自行管理 tool call 缓冲的场景（如 Anthropic handler 的 input_json_delta）
+     * 只用于 provider raw tool-argument delta；不要用于本地 tool result 或工具执行输出
+     */
+    reportToolArgDelta(deltaChars: number): void {
+        this.updateOutputSpeed(deltaChars);
+    }
+
+    /**
+     * 获取工具调用参数的字符串长度（用于完整 tool call 路径的速度统计）
+     */
+    private getToolArgsLength(args: Record<string, unknown> | object): number {
+        try {
+            return JSON.stringify(args)?.length ?? 0;
+        } catch {
+            return 0;
+        }
     }
 
     /**
@@ -292,9 +326,22 @@ export class StreamReporter {
 
     /**
      * 更新输出字符数并触发刷新（受 200ms 节流，结束时由 finishMetrics 强制最后一帧）
+     * 速度仅在收到实际输出字符时更新，暂停期间保持冻结
      */
     private updateOutputSpeed(addedChars: number): void {
+        if (addedChars <= 0) {
+            return;
+        }
+
         this.outputChars += addedChars;
+        this.lastOutputAt = Date.now();
+
+        const elapsedMs = this.firstStreamTime > 0
+            ? Math.max(1, this.lastOutputAt - this.firstStreamTime) : 0;
+
+        this.lastCharsPerSecond = elapsedMs > 0 && this.outputChars > 0
+            ? (this.outputChars / elapsedMs) * 1000 : 0;
+
         this.emitStreamingUpdate();
     }
 
@@ -354,6 +401,11 @@ export class StreamReporter {
             this.flushThinking('Before tool call start');
             this.flushText('Before tool call start');
             this.endThinkingChain();
+        }
+
+        // tool argument delta 是 provider 实际回传的一部分，计入 live chars/s
+        if (argsFragment) {
+            this.updateOutputSpeed(argsFragment.length);
         }
 
         if (!completed) {

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -11,6 +11,7 @@ import { encodeStatefulMarker, StatefulMarkerContainer } from './statefulMarker'
 import { toOptionalStatefulMarkerField } from './statefulMarkerCodec';
 import { CustomDataPartMimeTypes } from './types';
 import { TextBuffer, ThinkingBuffer, SignatureBuffer, ToolCallAccumulator } from './buffers';
+import type { LiveStreamMetricEvent } from '../metrics/liveMetrics';
 
 const USAGE_DATA_ENCODER = new TextEncoder();
 
@@ -32,6 +33,12 @@ export interface StreamReporterOptions {
     progress: vscode.Progress<vscode.LanguageModelResponsePart2>;
     /** 会话 ID（可选，如果不提供则自动生成） */
     sessionId?: string;
+    /** 请求 ID（可选，用于实时指标） */
+    requestId?: string;
+    /** 请求开始时间戳（可选，用于实时指标） */
+    requestStartTime?: number;
+    /** 实时指标回调（可选） */
+    onLiveMetrics?: (event: LiveStreamMetricEvent) => void;
 }
 
 /**
@@ -65,6 +72,18 @@ export class StreamReporter {
     private readonly provider: string;
     private readonly sdkMode: StatefulMarkerContainer['sdkMode'];
     private readonly progress: vscode.Progress<vscode.LanguageModelResponsePart2>;
+    private readonly requestId: string | undefined;
+    private readonly requestStartTime: number | undefined;
+    private readonly onLiveMetrics: ((event: LiveStreamMetricEvent) => void) | undefined;
+
+    // 实时指标状态
+    private firstChunkEmitted = false;
+    private streamEnded = false;
+    private outputChars = 0;
+    private lastLiveUpdateAt = 0;
+    private firstStreamTime = 0; // 首个流事件到达时间（与 handler 的 streamStartTime 对齐，共用时间戳）
+    private fixedFirstChunkLatencyMs = 0; // 固定的首令延迟（首流事件后不再变化）
+    private readonly LIVE_UPDATE_INTERVAL = 200; // 200ms 节流间隔
 
     private readonly textBuffer = new TextBuffer();
     private readonly thinkingBuffer = new ThinkingBuffer();
@@ -85,6 +104,109 @@ export class StreamReporter {
         this.sdkMode = options.sdkMode;
         this.progress = options.progress;
         this.sessionId = options.sessionId || crypto.randomUUID();
+        this.requestId = options.requestId;
+        this.requestStartTime = options.requestStartTime;
+        this.onLiveMetrics = options.onLiveMetrics;
+    }
+
+    /**
+     * 检查是否可以发送实时指标
+     */
+    private canEmitMetrics(): boolean {
+        return Boolean(
+            this.requestId &&
+            typeof this.requestStartTime === 'number' &&
+            Number.isFinite(this.requestStartTime) &&
+            this.onLiveMetrics
+        );
+    }
+
+    /**
+     * 标记流已开始（由 handler 在设置 streamStartTime 的同一时刻调用，共用同一个时间戳）
+     * @param streamStartTime handler 设置的 streamStartTime，必须与持久化记录一致
+     */
+    markStreamStarted(streamStartTime: number): void {
+        if (this.firstChunkEmitted || !this.canEmitMetrics()) {
+            return;
+        }
+
+        this.firstStreamTime = streamStartTime;
+        this.fixedFirstChunkLatencyMs = Math.max(0, streamStartTime - this.requestStartTime!);
+        this.firstChunkEmitted = true;
+
+        this.onLiveMetrics!({
+            type: 'firstChunk',
+            requestId: this.requestId!,
+            requestStartTime: this.requestStartTime!,
+            streamStartTime,
+            providerName: this.provider,
+            modelName: this.modelName,
+            firstChunkLatencyMs: this.fixedFirstChunkLatencyMs
+        });
+    }
+
+    /**
+     * 发送流式速度更新
+     * @param force 是否跳过 200ms 节流（供 finishMetrics 最后一帧使用）
+     */
+    private emitStreamingUpdate(force = false): void {
+        if (!this.canEmitMetrics()) {
+            return;
+        }
+
+        const now = Date.now();
+        if (!force && now - this.lastLiveUpdateAt < this.LIVE_UPDATE_INTERVAL) {
+            return;
+        }
+
+        // 首令延迟：已收到首流事件则使用固定值，否则从请求开始持续计时
+        const firstChunkLatencyMs = this.firstChunkEmitted
+            ? this.fixedFirstChunkLatencyMs
+            : Math.max(0, now - this.requestStartTime!);
+
+        // 输出耗时：从 firstStreamTime 开始计算
+        const elapsedMs = this.firstStreamTime > 0
+            ? Math.max(0, now - this.firstStreamTime)
+            : 0;
+
+        // 输出速度：实时重算，长暂停期间会自然下降
+        const charsPerSecond = elapsedMs > 0 && this.outputChars > 0
+            ? (this.outputChars / elapsedMs) * 1000
+            : 0;
+
+        this.onLiveMetrics!({
+            type: 'streamingUpdate',
+            requestId: this.requestId!,
+            requestStartTime: this.requestStartTime!,
+            streamStartTime: this.firstStreamTime > 0 ? this.firstStreamTime : undefined,
+            providerName: this.provider,
+            modelName: this.modelName,
+            firstChunkLatencyMs,
+            outputChars: this.outputChars,
+            elapsedMs,
+            charsPerSecond
+        });
+        this.lastLiveUpdateAt = now;
+    }
+
+    /**
+     * 结束实时指标上报（发送最后一帧 streamingUpdate，不发送 streamEnd）
+     * streamEnd 由 GenericModelProvider 在整个重试流程结束后发送
+     */
+    finishMetrics(): void {
+        if (this.streamEnded) {
+            return;
+        }
+        this.streamEnded = true;
+
+        if (!this.canEmitMetrics()) {
+            return;
+        }
+
+        // 只有已收到首个有效流事件时，才发送最后一帧 streamingUpdate
+        if (this.firstChunkEmitted) {
+            this.emitStreamingUpdate(true);
+        }
     }
 
     /**
@@ -106,6 +228,9 @@ export class StreamReporter {
 
         this.textBuffer.append(content);
         this.hasReceivedContent = true;
+
+        // 实时指标：更新输出字符数和速度
+        this.updateOutputSpeed(content.length);
 
         if (this.textBuffer.shouldFlush()) {
             const part = this.textBuffer.flush();
@@ -158,9 +283,28 @@ export class StreamReporter {
     }
 
     /**
+     * 心跳方法——触发受节流的轻量刷新。
+     * 不得调用 markStreamStarted()，不得自行固定流开始时间。
+     */
+    heartbeat(): void {
+        this.emitStreamingUpdate();
+    }
+
+    /**
+     * 更新输出字符数并触发刷新（受 200ms 节流，结束时由 finishMetrics 强制最后一帧）
+     */
+    private updateOutputSpeed(addedChars: number): void {
+        this.outputChars += addedChars;
+        this.emitStreamingUpdate();
+    }
+
+    /**
      * 缓冲思考内容（累积到阈值后输出，用于 delta 事件）
      */
     bufferThinking(content: string): void {
+        // 实时指标：更新输出字符数和速度
+        this.updateOutputSpeed(content.length);
+
         this.thinkingBuffer.append(content);
         this.hasThinkingContent = true;
 
@@ -381,6 +525,9 @@ export class StreamReporter {
 
         // 7. 报告 StatefulMarker
         this.reportStatefulMarker(customStatefulData);
+
+        // 8. 结束实时指标上报
+        this.finishMetrics();
 
         return this.hasReceivedContent;
     }

--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -80,8 +80,8 @@ export class StreamReporter {
     private firstChunkEmitted = false;
     private streamEnded = false;
     private outputChars = 0;
-    private lastCharsPerSecond = 0;  // 仅在收到实际 provider 输出字符时更新
-    private lastOutputAt = 0;        // 最后一次收到 provider 输出字符的时间（内部使用，不暴露给 WebView）
+    private lastCharsPerSecond = 0; // 仅在收到实际 provider 输出字符时更新
+    private lastOutputAt = 0; // 最后一次收到 provider 输出字符的时间（内部使用，不暴露给 WebView）
     private lastLiveUpdateAt = 0;
     private firstStreamTime = 0; // 首个流事件到达时间（与 handler 的 streamStartTime 对齐，共用时间戳）
     private fixedFirstChunkLatencyMs = 0; // 固定的首令延迟（首流事件后不再变化）
@@ -126,6 +126,13 @@ export class StreamReporter {
     /**
      * 标记流已开始（由 handler 在设置 streamStartTime 的同一时刻调用，共用同一个时间戳）
      * @param streamStartTime handler 设置的 streamStartTime，必须与持久化记录一致
+     *
+     * 各 handler 的首流事件时机不同：
+     * - Anthropic: message_start
+     * - OpenAI Chat SDK: 首个 chunk 事件
+     * - OpenAI Responses: response.created
+     * - Gemini/SSE: 首个有效 JSON event
+     * 本方法记录的是"首个流事件"，不等同于"首个可见文字"。
      */
     markStreamStarted(streamStartTime: number): void {
         if (this.firstChunkEmitted || !this.canEmitMetrics()) {
@@ -162,14 +169,11 @@ export class StreamReporter {
         }
 
         // 首令延迟：已收到首流事件则使用固定值，否则从请求开始持续计时
-        const firstChunkLatencyMs = this.firstChunkEmitted
-            ? this.fixedFirstChunkLatencyMs
-            : Math.max(0, now - this.requestStartTime!);
+        const firstChunkLatencyMs =
+            this.firstChunkEmitted ? this.fixedFirstChunkLatencyMs : Math.max(0, now - this.requestStartTime!);
 
         // 输出耗时：从 firstStreamTime 开始计算（仅用于耗时显示，不参与速度计算）
-        const elapsedMs = this.firstStreamTime > 0
-            ? Math.max(0, now - this.firstStreamTime)
-            : 0;
+        const elapsedMs = this.firstStreamTime > 0 ? Math.max(0, now - this.firstStreamTime) : 0;
 
         // 输出速度：使用 updateOutputSpeed 中缓存的值，暂停期间不会衰减
         const charsPerSecond = this.lastCharsPerSecond;
@@ -191,7 +195,9 @@ export class StreamReporter {
 
     /**
      * 结束实时指标上报（发送最后一帧 streamingUpdate，不发送 streamEnd）
-     * streamEnd 由 GenericModelProvider 在整个重试流程结束后发送
+     * streamEnd 由 GenericModelProvider 在整个重试流程结束后发送。
+     * 注意：本方法由 flushAll()（正常完成）和 handler finally（异常/取消）双路径调用，
+     * 通过 streamEnded 标志保证幂等——只有第一次调用生效。
      */
     finishMetrics(): void {
         if (this.streamEnded) {
@@ -329,18 +335,16 @@ export class StreamReporter {
      * 速度仅在收到实际输出字符时更新，暂停期间保持冻结
      */
     private updateOutputSpeed(addedChars: number): void {
-        if (addedChars <= 0) {
+        if (!Number.isFinite(addedChars) || addedChars <= 0) {
             return;
         }
 
         this.outputChars += addedChars;
         this.lastOutputAt = Date.now();
 
-        const elapsedMs = this.firstStreamTime > 0
-            ? Math.max(1, this.lastOutputAt - this.firstStreamTime) : 0;
+        const elapsedMs = this.firstStreamTime > 0 ? Math.max(1, this.lastOutputAt - this.firstStreamTime) : 0;
 
-        this.lastCharsPerSecond = elapsedMs > 0 && this.outputChars > 0
-            ? (this.outputChars / elapsedMs) * 1000 : 0;
+        this.lastCharsPerSecond = elapsedMs > 0 && this.outputChars > 0 ? (this.outputChars / elapsedMs) * 1000 : 0;
 
         this.emitStreamingUpdate();
     }

--- a/src/metrics/liveMetrics.ts
+++ b/src/metrics/liveMetrics.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Live Metrics
+ *  实时流式指标事件通道：供 StreamReporter 派发，TokenUsagesView/WebView 订阅。
+ *  不依赖 status 层，仅作为轻量 typed event bus。
+ *---------------------------------------------------------------------------------------------*/
+
+import { Logger } from '../utils/logger';
+
+export interface LiveStreamMetricEvent {
+    type: 'requestStarted' | 'firstChunk' | 'streamingUpdate' | 'streamEnd';
+    requestId: string;
+    requestStartTime: number;
+    providerName: string;
+    modelName: string;
+    streamStartTime?: number;
+    firstChunkLatencyMs?: number;
+    outputChars?: number;
+    elapsedMs?: number;
+    charsPerSecond?: number;
+}
+
+type LiveMetricsListener = (event: LiveStreamMetricEvent) => void;
+
+const listeners = new Set<LiveMetricsListener>();
+
+export function onLiveMetrics(listener: LiveMetricsListener): { dispose(): void } {
+    listeners.add(listener);
+    return {
+        dispose: () => {
+            listeners.delete(listener);
+        }
+    };
+}
+
+export function emitLiveMetrics(event: LiveStreamMetricEvent): void {
+    if (listeners.size === 0) {
+        return;
+    }
+
+    for (const listener of listeners) {
+        try {
+            listener(event);
+        } catch (error) {
+            Logger.warn('[LiveMetrics] listener failed:', error);
+        }
+    }
+}

--- a/src/metrics/liveMetrics.ts
+++ b/src/metrics/liveMetrics.ts
@@ -15,7 +15,6 @@ export interface LiveStreamMetricEvent {
     streamStartTime?: number;
     firstChunkLatencyMs?: number;
     outputChars?: number;
-    elapsedMs?: number;
     charsPerSecond?: number;
 }
 

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -601,7 +601,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         traceId: otelTraceContext.traceId,
                         spanId: otelTraceContext.spanId
                     }
-                    : undefined
+                :   undefined
         };
     }
 

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils';
 import { getEffectiveMaxInputTokens } from '../utils/languageModelInfo';
 import type { RetryableError } from '../utils';
+import * as liveMetrics from '../metrics/liveMetrics';
 import { OpenAIHandler } from '../handlers/openaiHandler';
 import { OpenAICustomHandler } from '../handlers/openaiCustomHandler';
 import { AnthropicHandler } from '../handlers/anthropicHandler';
@@ -459,7 +460,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
         requestId: string,
         sessionId: string,
         token: CancellationToken,
-        effectiveProviderKey = modelConfig.provider || this.providerKey
+        effectiveProviderKey = modelConfig.provider || this.providerKey,
+        requestStartTime = Date.now()
     ): Promise<void> {
         const sdkMode = modelConfig.sdkMode || 'openai';
         const retryManager = new RetryManager(this.getRequestRetryConfig());
@@ -496,7 +498,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         progress,
                         requestId,
                         sessionId,
-                        token
+                        token,
+                        requestStartTime
                     );
                 } else if (sdkMode === 'gemini-sse') {
                     await this.geminiHandler.handleRequest(
@@ -507,7 +510,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         progress,
                         requestId,
                         sessionId,
-                        token
+                        token,
+                        requestStartTime
                     );
                 } else if (sdkMode === 'openai-sse') {
                     await this.openaiCustomHandler.handleRequest(
@@ -518,7 +522,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         progress,
                         requestId,
                         sessionId,
-                        token
+                        token,
+                        requestStartTime
                     );
                 } else if (sdkMode === 'openai-responses') {
                     await this.openaiResponsesHandler.handleResponsesRequest(
@@ -529,7 +534,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         progress,
                         requestId,
                         sessionId,
-                        token
+                        token,
+                        requestStartTime
                     );
                 } else {
                     await this.openaiHandler.handleRequest(
@@ -540,7 +546,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         progress,
                         requestId,
                         sessionId,
-                        token
+                        token,
+                        requestStartTime
                     );
                 }
             },
@@ -611,25 +618,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             options
         );
 
-        // === Token 统计: 记录预估输入 token ===
-        const usagesManager = TokenUsagesManager.instance;
-        let requestId = '';
+        // 提取或生成 sessionId（根据 sdkMode，新会话时生成 UUID）
         const sessionId = this.getSessionIdFromMessages(messages, sdkMode);
-        try {
-            requestId = await usagesManager.recordEstimatedTokens({
-                providerKey: effectiveProviderKey,
-                displayName: this.providerConfig.displayName,
-                modelId: model.id,
-                modelName: model.name || modelConfig.name,
-                estimatedInputTokens: totalInputTokens,
-                maxInputTokens,
-                requestKind: rtOpts.modelOptions.requestKind ?? kind,
-                sessionId,
-                ...this.getEstimatedRequestMetadata(options)
-            });
-        } catch (err) {
-            Logger.warn('Failed to record estimated tokens, continuing request:', err);
-        }
 
         // 根据模型的 sdkMode 选择使用的 handler
         const sdkName = this.getSdkDisplayName(sdkMode);
@@ -637,9 +627,45 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             `${this.providerConfig.displayName} Provider started handling request (${sdkName}): ${modelConfig.name}`
         );
 
+        // === Token 统计: 记录预估输入 token ===
+        const usagesManager = TokenUsagesManager.instance;
+        let requestId = '';
+        let requestStartTime = Date.now();
+
         try {
             // 确保对应提供商的 API 密钥存在
             await ApiKeyManager.ensureApiKey(effectiveProviderKey, this.providerConfig.displayName);
+
+            // API Key 确认后才开始计时，避免用户输入密钥的时间计入 TTFT
+            requestStartTime = Date.now();
+
+            try {
+                requestId = await usagesManager.recordEstimatedTokens({
+                    providerKey: effectiveProviderKey,
+                    displayName: this.providerConfig.displayName,
+                    modelId: model.id,
+                    modelName: model.name || modelConfig.name,
+                    estimatedInputTokens: totalInputTokens,
+                    maxInputTokens,
+                    requestKind: rtOpts.modelOptions.requestKind ?? kind,
+                    sessionId,
+                    timestamp: requestStartTime,
+                    ...this.getEstimatedRequestMetadata(options)
+                });
+            } catch (err) {
+                Logger.warn('Failed to record estimated tokens, continuing request:', err);
+            }
+
+            // 派发请求开始事件，使 WebView 首令延迟从 0 开始滚动
+            if (requestId) {
+                liveMetrics.emitLiveMetrics({
+                    type: 'requestStarted',
+                    requestId,
+                    requestStartTime,
+                    providerName: this.providerConfig.displayName,
+                    modelName: model.name || modelConfig.name
+                });
+            }
 
             await this.executeModelRequest(
                 model,
@@ -650,7 +676,8 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                 requestId,
                 sessionId,
                 token,
-                effectiveProviderKey
+                effectiveProviderKey,
+                requestStartTime
             );
         } catch (error) {
             const errorMessage = `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
@@ -660,6 +687,16 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             // 直接抛出错误，让VS Code处理重试
             throw error;
         } finally {
+            // 整个重试流程结束后发送 streamEnd，清理 WebView 实时状态
+            if (requestId) {
+                liveMetrics.emitLiveMetrics({
+                    type: 'streamEnd',
+                    requestId,
+                    requestStartTime,
+                    providerName: this.providerConfig.displayName,
+                    modelName: model.name || modelConfig.name
+                });
+            }
             Logger.info(`✅ ${this.providerConfig.displayName}: ${model.name} request completed`);
         }
     }

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -672,7 +672,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             // 注意：该时间点是 provider 请求处理起点，不是严格的网络请求发出时刻；
             // 可能包含预估 token 记录、请求体构建、SDK/client 初始化、CLI 版本探测等本地准备开销。
             // 因此 live TTFT 表示"provider 开始处理到首个流事件"的近似延迟，
-            // 不应在 UI 或日志中描述为"网络请求发出后首令延迟"。
+            // 不应在 UI 或日志中描述为"网络请求发出后首流延迟"。
             requestStartTime = Date.now();
 
             try {

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -661,7 +661,11 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             // 确保对应提供商的 API 密钥存在
             await ApiKeyManager.ensureApiKey(effectiveProviderKey, this.providerConfig.displayName);
 
-            // API Key 确认后才开始计时，避免用户输入密钥的时间计入 TTFT
+            // API Key 确认后开始计时，避免用户输入/授权时间计入实时延迟。
+            // 注意：该时间点是 provider 请求处理起点，不是严格的网络请求发出时刻；
+            // 可能包含预估 token 记录、请求体构建、SDK/client 初始化、CLI 版本探测等本地准备开销。
+            // 因此 live TTFT 表示"provider 开始处理到首个流事件"的近似延迟，
+            // 不应在 UI 或日志中描述为"网络请求发出后首令延迟"。
             requestStartTime = Date.now();
 
             try {

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -464,6 +464,18 @@ export class GenericModelProvider implements LanguageModelChatProvider {
         requestStartTime = Date.now()
     ): Promise<void> {
         const sdkMode = modelConfig.sdkMode || 'openai';
+
+        // 派发请求开始事件，使 WebView 首令延迟从 0 开始滚动
+        if (requestId) {
+            liveMetrics.emitLiveMetrics({
+                type: 'requestStarted',
+                requestId,
+                requestStartTime,
+                providerName: this.providerConfig.displayName,
+                modelName: model.name || modelConfig.name
+            });
+        }
+
         const retryManager = new RetryManager(this.getRequestRetryConfig());
 
         // 请求分类（仅当上层未设置时写入，避免覆盖 provideLanguageModelChatResponse 的值）
@@ -487,73 +499,86 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             }
         }
 
-        await retryManager.executeWithRetry(
-            async () => {
-                if (sdkMode === 'anthropic') {
-                    await this.anthropicHandler.handleRequest(
-                        model,
-                        modelConfig,
-                        messages,
-                        options,
-                        progress,
-                        requestId,
-                        sessionId,
-                        token,
-                        requestStartTime
-                    );
-                } else if (sdkMode === 'gemini-sse') {
-                    await this.geminiHandler.handleRequest(
-                        model,
-                        modelConfig,
-                        messages,
-                        options,
-                        progress,
-                        requestId,
-                        sessionId,
-                        token,
-                        requestStartTime
-                    );
-                } else if (sdkMode === 'openai-sse') {
-                    await this.openaiCustomHandler.handleRequest(
-                        model,
-                        modelConfig,
-                        messages,
-                        options,
-                        progress,
-                        requestId,
-                        sessionId,
-                        token,
-                        requestStartTime
-                    );
-                } else if (sdkMode === 'openai-responses') {
-                    await this.openaiResponsesHandler.handleResponsesRequest(
-                        model,
-                        { ...modelConfig, provider: effectiveProviderKey },
-                        messages,
-                        options,
-                        progress,
-                        requestId,
-                        sessionId,
-                        token,
-                        requestStartTime
-                    );
-                } else {
-                    await this.openaiHandler.handleRequest(
-                        model,
-                        modelConfig,
-                        messages,
-                        options,
-                        progress,
-                        requestId,
-                        sessionId,
-                        token,
-                        requestStartTime
-                    );
-                }
-            },
-            error => this.shouldRetryRequest(error),
-            this.providerConfig.displayName
-        );
+        try {
+            await retryManager.executeWithRetry(
+                async () => {
+                    if (sdkMode === 'anthropic') {
+                        await this.anthropicHandler.handleRequest(
+                            model,
+                            modelConfig,
+                            messages,
+                            options,
+                            progress,
+                            requestId,
+                            sessionId,
+                            token,
+                            requestStartTime
+                        );
+                    } else if (sdkMode === 'gemini-sse') {
+                        await this.geminiHandler.handleRequest(
+                            model,
+                            modelConfig,
+                            messages,
+                            options,
+                            progress,
+                            requestId,
+                            sessionId,
+                            token,
+                            requestStartTime
+                        );
+                    } else if (sdkMode === 'openai-sse') {
+                        await this.openaiCustomHandler.handleRequest(
+                            model,
+                            modelConfig,
+                            messages,
+                            options,
+                            progress,
+                            requestId,
+                            sessionId,
+                            token,
+                            requestStartTime
+                        );
+                    } else if (sdkMode === 'openai-responses') {
+                        await this.openaiResponsesHandler.handleResponsesRequest(
+                            model,
+                            { ...modelConfig, provider: effectiveProviderKey },
+                            messages,
+                            options,
+                            progress,
+                            requestId,
+                            sessionId,
+                            token,
+                            requestStartTime
+                        );
+                    } else {
+                        await this.openaiHandler.handleRequest(
+                            model,
+                            modelConfig,
+                            messages,
+                            options,
+                            progress,
+                            requestId,
+                            sessionId,
+                            token,
+                            requestStartTime
+                        );
+                    }
+                },
+                error => this.shouldRetryRequest(error),
+                this.providerConfig.displayName
+            );
+        } finally {
+            // 整个重试流程结束后发送 streamEnd，清理 WebView 实时状态
+            if (requestId) {
+                liveMetrics.emitLiveMetrics({
+                    type: 'streamEnd',
+                    requestId,
+                    requestStartTime,
+                    providerName: this.providerConfig.displayName,
+                    modelName: model.name || modelConfig.name
+                });
+            }
+        }
     }
 
     protected getEstimatedRequestMetadata(options: ProvideLanguageModelChatResponseOptions): {
@@ -576,7 +601,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                         traceId: otelTraceContext.traceId,
                         spanId: otelTraceContext.spanId
                     }
-                :   undefined
+                    : undefined
         };
     }
 
@@ -656,17 +681,6 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                 Logger.warn('Failed to record estimated tokens, continuing request:', err);
             }
 
-            // 派发请求开始事件，使 WebView 首令延迟从 0 开始滚动
-            if (requestId) {
-                liveMetrics.emitLiveMetrics({
-                    type: 'requestStarted',
-                    requestId,
-                    requestStartTime,
-                    providerName: this.providerConfig.displayName,
-                    modelName: model.name || modelConfig.name
-                });
-            }
-
             await this.executeModelRequest(
                 model,
                 modelConfig,
@@ -687,16 +701,6 @@ export class GenericModelProvider implements LanguageModelChatProvider {
             // 直接抛出错误，让VS Code处理重试
             throw error;
         } finally {
-            // 整个重试流程结束后发送 streamEnd，清理 WebView 实时状态
-            if (requestId) {
-                liveMetrics.emitLiveMetrics({
-                    type: 'streamEnd',
-                    requestId,
-                    requestStartTime,
-                    providerName: this.providerConfig.displayName,
-                    modelName: model.name || modelConfig.name
-                });
-            }
             Logger.info(`✅ ${this.providerConfig.displayName}: ${model.name} request completed`);
         }
     }

--- a/src/providers/genericModelProvider.ts
+++ b/src/providers/genericModelProvider.ts
@@ -465,16 +465,9 @@ export class GenericModelProvider implements LanguageModelChatProvider {
     ): Promise<void> {
         const sdkMode = modelConfig.sdkMode || 'openai';
 
-        // 派发请求开始事件，使 WebView 首令延迟从 0 开始滚动
-        if (requestId) {
-            liveMetrics.emitLiveMetrics({
-                type: 'requestStarted',
-                requestId,
-                requestStartTime,
-                providerName: this.providerConfig.displayName,
-                modelName: model.name || modelConfig.name
-            });
-        }
+        // requestStarted 不再在外层发射，而是移入 retry callback 内部，
+        // 每次 attempt 使用 liveAttemptStartTime 作为 live metrics 时间基准。
+        // 外层 requestStartTime 保留给 recordEstimatedTokens / 持久化记录使用。
 
         const retryManager = new RetryManager(this.getRequestRetryConfig());
 
@@ -502,6 +495,20 @@ export class GenericModelProvider implements LanguageModelChatProvider {
         try {
             await retryManager.executeWithRetry(
                 async () => {
+                    // 每次 attempt（含首次和 retry）使用独立时间基准，
+                    // 确保 live TTFT 只反映当前 attempt 的耗时，不包含重试等待。
+                    const liveAttemptStartTime = Date.now();
+
+                    if (requestId) {
+                        liveMetrics.emitLiveMetrics({
+                            type: 'requestStarted',
+                            requestId,
+                            requestStartTime: liveAttemptStartTime,
+                            providerName: this.providerConfig.displayName,
+                            modelName: model.name || modelConfig.name
+                        });
+                    }
+
                     if (sdkMode === 'anthropic') {
                         await this.anthropicHandler.handleRequest(
                             model,
@@ -512,7 +519,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                             requestId,
                             sessionId,
                             token,
-                            requestStartTime
+                            liveAttemptStartTime
                         );
                     } else if (sdkMode === 'gemini-sse') {
                         await this.geminiHandler.handleRequest(
@@ -524,7 +531,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                             requestId,
                             sessionId,
                             token,
-                            requestStartTime
+                            liveAttemptStartTime
                         );
                     } else if (sdkMode === 'openai-sse') {
                         await this.openaiCustomHandler.handleRequest(
@@ -536,7 +543,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                             requestId,
                             sessionId,
                             token,
-                            requestStartTime
+                            liveAttemptStartTime
                         );
                     } else if (sdkMode === 'openai-responses') {
                         await this.openaiResponsesHandler.handleResponsesRequest(
@@ -548,7 +555,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                             requestId,
                             sessionId,
                             token,
-                            requestStartTime
+                            liveAttemptStartTime
                         );
                     } else {
                         await this.openaiHandler.handleRequest(
@@ -560,7 +567,7 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                             requestId,
                             sessionId,
                             token,
-                            requestStartTime
+                            liveAttemptStartTime
                         );
                     }
                 },

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -135,6 +135,8 @@ interface LiveMetricsState {
     streamStartTime?: number;
     firstChunkLatencyMs: number;
     outputChars: number;
+    charsPerSecond: number;
+    lastOutputChangeAt: number; // 最后一次 provider 可计数字符增加的时间
     providerName?: string;
     modelName?: string;
 }
@@ -186,6 +188,8 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 requestStartTime: event.requestStartTime,
                 firstChunkLatencyMs: 0,
                 outputChars: 0,
+                charsPerSecond: 0,
+                lastOutputChangeAt: 0,
                 providerName: event.providerName,
                 modelName: event.modelName
             });
@@ -198,6 +202,8 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 requestStartTime: event.requestStartTime,
                 firstChunkLatencyMs: 0,
                 outputChars: 0,
+                charsPerSecond: 0,
+                lastOutputChangeAt: 0,
                 providerName: event.providerName,
                 modelName: event.modelName
             };
@@ -219,6 +225,8 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                     streamStartTime: event.streamStartTime,
                     firstChunkLatencyMs: event.firstChunkLatencyMs ?? 0,
                     outputChars: 0,
+                    charsPerSecond: 0,
+                    lastOutputChangeAt: 0,
                     providerName: event.providerName,
                     modelName: event.modelName
                 };
@@ -226,7 +234,13 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 startRenderClock();
             }
             state.requestStartTime = event.requestStartTime;
-            state.outputChars = event.outputChars ?? 0;
+            // 只在 outputChars 实际增加时更新 lastOutputChangeAt（避免 heartbeat/ping 误刷新）
+            const previousOutputChars = state.outputChars;
+            if (event.outputChars !== undefined && event.outputChars > previousOutputChars) {
+                state.outputChars = event.outputChars;
+                state.lastOutputChangeAt = Date.now();
+            }
+            state.charsPerSecond = event.charsPerSecond ?? state.charsPerSecond;
             // 补齐 provider/model（requestStarted 可能未被 WebView 接收到）
             state.providerName = state.providerName || event.providerName;
             state.modelName = state.modelName || event.modelName;
@@ -414,10 +428,8 @@ function updateRequestRecordsWithLiveMetrics(): void {
             ? Math.max(0, now - metricState.streamStartTime!)
             : 0;
 
-        // 实时计算输出速度：outputChars / elapsedMs
-        const charsPerSecond = durationMs > 0 && metricState.outputChars > 0
-            ? (metricState.outputChars / durationMs) * 1000
-            : 0;
+        // 输出速度：使用 StreamReporter 缓存的值，暂停期间不会衰减
+        const charsPerSecond = metricState.charsPerSecond ?? 0;
 
         // 更新首令延迟 + 输出耗时 + 速度
         const outputCell = targetRow.querySelector('td.records-output-merged[data-metric="output"]') as HTMLElement;
@@ -437,12 +449,26 @@ function updateRequestRecordsWithLiveMetrics(): void {
             // .output-tokens 在 streaming 阶段不更新，等最终 usage 回写
             const speedSpan = outputCell.querySelector('.output-speed') as HTMLElement;
             if (speedSpan) {
-                speedSpan.textContent = charsPerSecond > 0 ?
-                    `~${charsPerSecond.toFixed(1)} chars/s` : '-';
-                speedSpan.title = t(
-                    'Live speed is estimated by streamed characters; final speed uses output tokens.',
-                    '实时速度按流式字符估算，完成后以输出 token/s 为准。'
-                );
+                // 过时检测：长时间没有新的 provider 输出时，避免冻结的旧 speed 被误解为仍在实时更新
+                const lastOutputChangeAt = metricState.lastOutputChangeAt ?? 0;
+                const outputStaleMs = lastOutputChangeAt > 0 ? now - lastOutputChangeAt : 0;
+                const isStale = hasStreamStarted && metricState.outputChars > 0 && lastOutputChangeAt > 0 && outputStaleMs > 3000;
+
+                if (isStale) {
+                    speedSpan.textContent = t('⏳ waiting...', '⏳ 等待回传...');
+                    speedSpan.title = t(
+                        'No new provider output chunk has arrived recently. Some compatible endpoints buffer tool arguments and send them in a later chunk; speed will update when new output arrives.',
+                        '近期未收到新的 provider 输出分片。部分兼容端点会缓冲工具参数并稍后一次性发送；速度将在收到新输出时更新。'
+                    );
+                } else if (charsPerSecond > 0) {
+                    speedSpan.textContent = `~${charsPerSecond.toFixed(1)} chars/s`;
+                    speedSpan.title = t(
+                        'Live speed is estimated by streamed characters; final speed uses output tokens.',
+                        '实时速度按流式字符估算，完成后以输出 token/s 为准。'
+                    );
+                } else {
+                    speedSpan.textContent = '-';
+                }
             }
         }
     });

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -224,6 +224,11 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                         Math.max(0, event.streamStartTime - event.requestStartTime)
                         : 0);
                 chunkState.hasFirstChunk = true;
+            } else {
+                // retry/new reporter: keep original firstChunkLatencyMs, reset per-attempt output state
+                chunkState.outputChars = 0;
+                chunkState.charsPerSecond = 0;
+                chunkState.lastOutputChangeAt = 0;
             }
             chunkState.providerName = chunkState.providerName || event.providerName;
             chunkState.modelName = chunkState.modelName || event.modelName;
@@ -271,7 +276,7 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
         }
 
         case 'streamEnd': {
-            removeLivePlaceholderRow(requestId);
+            markLivePlaceholderFinishing(requestId);
             liveMetricsMap.delete(requestId);
             if (liveMetricsMap.size === 0) {
                 stopRenderClock();
@@ -286,31 +291,61 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
 }
 
 /**
- * 清理由实时指标创建的临时占位行（streamEnd 时调用）
- * 仅删除标记为 data-live-placeholder 的行，不误删由 updateDateDetails 渲染的真实记录行
+ * 查找指定 requestId 的实时占位行
  */
-function removeLivePlaceholderRow(requestId: string): void {
+function findLivePlaceholderRow(requestId: string): HTMLTableRowElement | null {
     const recordsContainer = document.querySelector('#records-container') as HTMLElement | null;
     const tbody = recordsContainer?.querySelector('tbody');
     if (!tbody) {
+        return null;
+    }
+    return Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr[data-live-placeholder="true"]'))
+        .find(r => r.dataset.requestId === requestId) ?? null;
+}
+
+/**
+ * 占位行全部删除后，若表格为空则恢复"暂无请求记录"空行
+ */
+function ensureEmptyRowIfNeeded(): void {
+    const recordsContainer = document.querySelector('#records-container') as HTMLElement | null;
+    const tbody = recordsContainer?.querySelector('tbody');
+    if (!tbody || tbody.querySelector('tr')) {
         return;
     }
-    const row = Array.from(tbody.querySelectorAll('tr')).find(r => r.getAttribute('data-request-id') === requestId) as
-        | HTMLTableRowElement
-        | undefined;
-    if (row?.getAttribute('data-live-placeholder') === 'true') {
-        row.remove();
-        // 占位行删除后若表格为空，恢复"暂无请求记录"空行
-        if (!tbody.querySelector('tr')) {
-            const emptyRow = document.createElement('tr');
-            const emptyCell = document.createElement('td');
-            emptyCell.colSpan = 6;
-            emptyCell.textContent = t('No request records yet', '暂无请求记录');
-            emptyCell.style.textAlign = 'center';
-            emptyRow.appendChild(emptyCell);
-            tbody.appendChild(emptyRow);
-        }
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = 6;
+    emptyCell.textContent = t('No request records yet', '暂无请求记录');
+    emptyCell.style.textAlign = 'center';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+}
+
+/**
+ * 将实时占位行标记为 finishing 状态（streamEnd 时调用）
+ * 不立即删除，等 updateDateDetails 重建表格时自然替换；
+ * 5 秒兜底删除防止占位行永久残留。
+ */
+function markLivePlaceholderFinishing(requestId: string): void {
+    const row = findLivePlaceholderRow(requestId);
+    if (!row) {
+        return;
     }
+
+    // 直接操作 DOM：liveMetricsMap.delete 后 rAF 不会再刷新该行
+    if (row.dataset.liveFinishing === 'true') {
+        return;
+    }
+    row.dataset.liveFinishing = 'true';
+
+    // 5 秒兜底：重新查询确认仍是 live placeholder 才删除，避免误删已替换的真实记录
+    window.setTimeout(() => {
+        const currentRow = findLivePlaceholderRow(requestId);
+        if (currentRow?.dataset.liveFinishing === 'true') {
+            currentRow.remove();
+            ensureEmptyRowIfNeeded();
+        }
+    }, 5000);
 }
 
 /**
@@ -401,8 +436,8 @@ function updateRequestRecordsWithLiveMetrics(): void {
             outputMergedCell.className = 'records-output-merged';
             outputMergedCell.setAttribute('data-metric', 'output');
             outputMergedCell.innerHTML =
-                `<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>` +
-                `<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>`;
+                '<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>' +
+                '<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>';
             targetRow.appendChild(outputMergedCell);
 
             // 消耗令牌
@@ -447,8 +482,8 @@ function updateRequestRecordsWithLiveMetrics(): void {
             // 防御性兜底：兼容旧 DOM 或未来变更，确保 span 结构存在
             if (!outputCell.querySelector('.output-ttft')) {
                 outputCell.innerHTML =
-                    `<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>` +
-                    `<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>`;
+                    '<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>' +
+                    '<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>';
             }
             const ttftSpan = outputCell.querySelector('.output-ttft') as HTMLElement;
             if (ttftSpan) {

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -222,7 +222,7 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                     event.firstChunkLatencyMs ??
                     (event.streamStartTime !== undefined ?
                         Math.max(0, event.streamStartTime - event.requestStartTime)
-                    :   0);
+                        : 0);
                 chunkState.hasFirstChunk = true;
             }
             chunkState.providerName = chunkState.providerName || event.providerName;
@@ -304,7 +304,7 @@ function removeLivePlaceholderRow(requestId: string): void {
         if (!tbody.querySelector('tr')) {
             const emptyRow = document.createElement('tr');
             const emptyCell = document.createElement('td');
-            emptyCell.colSpan = 10;
+            emptyCell.colSpan = 6;
             emptyCell.textContent = t('No request records yet', '暂无请求记录');
             emptyCell.style.textAlign = 'center';
             emptyRow.appendChild(emptyCell);
@@ -376,45 +376,39 @@ function updateRequestRecordsWithLiveMetrics(): void {
             timeCell.textContent = new Date(metricState.requestStartTime).toLocaleTimeString('zh-CN');
             targetRow.appendChild(timeCell);
 
-            // 提供商
-            const providerCell = document.createElement('td');
-            providerCell.textContent = metricState.providerName || '-';
-            targetRow.appendChild(providerCell);
-
-            // 模型
-            const modelCell = document.createElement('td');
-            modelCell.textContent = metricState.modelName || '-';
-            targetRow.appendChild(modelCell);
+            // 提供商 + 模型（双行合并）
+            const providerModelCell = document.createElement('td');
+            const provName = metricState.providerName || '-';
+            const modName = metricState.modelName || '-';
+            providerModelCell.title = `${provName} · ${modName}`;
+            const providerDiv = document.createElement('div');
+            providerDiv.className = 'prov-model-provider';
+            providerDiv.textContent = provName;
+            const modelDiv = document.createElement('div');
+            modelDiv.className = 'prov-model-model';
+            modelDiv.textContent = modName;
+            providerModelCell.append(providerDiv, modelDiv);
+            targetRow.appendChild(providerModelCell);
 
             // 输入令牌
             const inputCell = document.createElement('td');
+            inputCell.className = 'records-input-merged';
             inputCell.textContent = '-';
             targetRow.appendChild(inputCell);
 
-            // 缓存命中
-            const cacheCell = document.createElement('td');
-            cacheCell.textContent = '-';
-            targetRow.appendChild(cacheCell);
-
-            // 输出令牌
-            const outputCell = document.createElement('td');
-            outputCell.textContent = '-';
-            targetRow.appendChild(outputCell);
+            // 输出列（合并：TTFT / tokens / TPOT / speed）
+            const outputMergedCell = document.createElement('td');
+            outputMergedCell.className = 'records-output-merged';
+            outputMergedCell.setAttribute('data-metric', 'output');
+            outputMergedCell.innerHTML =
+                `<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>` +
+                `<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>`;
+            targetRow.appendChild(outputMergedCell);
 
             // 消耗令牌
             const totalCell = document.createElement('td');
             totalCell.textContent = '-';
             targetRow.appendChild(totalCell);
-
-            // 首令延迟 + 输出耗时
-            const timingCell = document.createElement('td');
-            timingCell.setAttribute('data-metric', 'timing');
-            targetRow.appendChild(timingCell);
-
-            // 输出速度
-            const speedCell = document.createElement('td');
-            speedCell.setAttribute('data-metric', 'speed');
-            targetRow.appendChild(speedCell);
 
             // 状态
             const statusCell = document.createElement('td');
@@ -450,6 +444,12 @@ function updateRequestRecordsWithLiveMetrics(): void {
         // 更新首令延迟 + 输出耗时 + 速度
         const outputCell = targetRow.querySelector('td.records-output-merged[data-metric="output"]') as HTMLElement;
         if (outputCell) {
+            // 防御性兜底：兼容旧 DOM 或未来变更，确保 span 结构存在
+            if (!outputCell.querySelector('.output-ttft')) {
+                outputCell.innerHTML =
+                    `<div class="output-row"><span class="output-ttft">-</span><span class="output-tokens">-</span></div>` +
+                    `<div class="output-detail"><span class="output-tpot">-</span><span class="output-speed">-</span></div>`;
+            }
             const ttftSpan = outputCell.querySelector('.output-ttft') as HTMLElement;
             if (ttftSpan) {
                 ttftSpan.title = '首流延迟：从 provider 开始处理请求到首个流事件的近似耗时，不一定是首个可见文字';
@@ -517,7 +517,7 @@ function handleVSCodeMessage(event: MessageEvent): void {
                     sessionGroups.some(group => group.sessionId === state.selectedSessionId)
                 ) ?
                     state.selectedSessionId
-                :   null;
+                    : null;
 
             if (dateChanged) {
                 resetRequestRecordsState();

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -6,6 +6,7 @@ import './style.less';
 import 'chart.js/auto'; // 导入 Chart.js
 
 import type { HostMessage, State } from './types';
+import type { LiveStreamMetricEvent } from '../../metrics/liveMetrics';
 import { getTodayDateString, groupRecordsBySession, postToVSCode, t } from './utils';
 import { createElement } from '../utils';
 
@@ -127,6 +128,195 @@ function updateLoadingOverlay(): void {
 }
 
 /**
+ * 单个请求的实时流式指标状态
+ */
+interface LiveMetricsState {
+    requestStartTime: number;
+    streamStartTime?: number;
+    firstChunkLatencyMs: number;
+    outputChars: number;
+}
+
+// 支持多个并发请求的实时指标状态
+const liveMetricsMap = new Map<string, LiveMetricsState>();
+
+// 共享渲染时钟（rAF + 200ms 节流）
+const LIVE_RENDER_INTERVAL_MS = 200;
+let renderClockId: number | undefined;
+let lastRenderAt = 0;
+
+function startRenderClock(): void {
+    if (renderClockId !== undefined) {
+        return;
+    }
+    const tick = (frameTime: number): void => {
+        if (liveMetricsMap.size === 0) {
+            renderClockId = undefined;
+            lastRenderAt = 0;
+            return;
+        }
+        if (frameTime - lastRenderAt >= LIVE_RENDER_INTERVAL_MS) {
+            updateRequestRecordsWithLiveMetrics();
+            lastRenderAt = frameTime;
+        }
+        renderClockId = requestAnimationFrame(tick);
+    };
+    renderClockId = requestAnimationFrame(tick);
+}
+
+function stopRenderClock(): void {
+    if (renderClockId !== undefined) {
+        cancelAnimationFrame(renderClockId);
+        renderClockId = undefined;
+    }
+    lastRenderAt = 0;
+}
+
+/**
+ * 处理实时流式指标更新
+ */
+function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
+    const { requestId } = event;
+
+    switch (event.type) {
+        case 'requestStarted':
+            liveMetricsMap.set(requestId, {
+                requestStartTime: event.requestStartTime,
+                firstChunkLatencyMs: 0,
+                outputChars: 0
+            });
+            startRenderClock();
+            break;
+
+        case 'firstChunk': {
+            // upsert：requestStarted 可能因面板未打开/日期切换而丢失
+            const chunkState = liveMetricsMap.get(requestId) ?? {
+                requestStartTime: event.requestStartTime,
+                firstChunkLatencyMs: 0,
+                outputChars: 0
+            };
+            chunkState.requestStartTime = event.requestStartTime;
+            chunkState.streamStartTime = event.streamStartTime;
+            chunkState.firstChunkLatencyMs = event.firstChunkLatencyMs ?? 0;
+            liveMetricsMap.set(requestId, chunkState);
+            startRenderClock();
+            break;
+        }
+
+        case 'streamingUpdate': {
+            let state = liveMetricsMap.get(requestId);
+            if (!state) {
+                state = {
+                    requestStartTime: event.requestStartTime,
+                    streamStartTime: event.streamStartTime,
+                    firstChunkLatencyMs: event.firstChunkLatencyMs ?? 0,
+                    outputChars: 0
+                };
+                liveMetricsMap.set(requestId, state);
+                startRenderClock();
+            }
+            state.requestStartTime = event.requestStartTime;
+            state.outputChars = event.outputChars ?? 0;
+            if (event.streamStartTime !== undefined) {
+                state.streamStartTime = event.streamStartTime;
+            }
+            if (event.firstChunkLatencyMs !== undefined) {
+                state.firstChunkLatencyMs = event.firstChunkLatencyMs;
+            }
+            break;
+        }
+
+        case 'streamEnd': {
+            liveMetricsMap.delete(requestId);
+            if (liveMetricsMap.size === 0) {
+                stopRenderClock();
+            }
+            updateRequestRecordsWithLiveMetrics();
+            return;
+        }
+    }
+
+    // 触发请求记录区域的更新
+    updateRequestRecordsWithLiveMetrics();
+}
+
+/**
+ * 更新请求记录区域，显示实时指标
+ * 策略：遍历所有正在流式的请求，通过 requestId 精确匹配表格行并更新
+ */
+function updateRequestRecordsWithLiveMetrics(): void {
+    const recordsContainer = document.querySelector('#records-container') as HTMLElement;
+    if (!recordsContainer) {
+        return;
+    }
+
+    const tbody = recordsContainer.querySelector('tbody');
+    if (!tbody) {
+        return;
+    }
+
+    const now = Date.now();
+
+    liveMetricsMap.forEach((state, requestId) => {
+        const targetRow = Array.from(tbody.querySelectorAll('tr'))
+            .find(row => row.getAttribute('data-request-id') === requestId) as HTMLTableRowElement | undefined;
+
+        if (!targetRow) {
+            return;
+        }
+
+        // 跳过已完成/失败的行，避免实时值覆盖最终统计
+        const requestStatus = targetRow.getAttribute('data-request-status');
+        if (requestStatus === 'completed' || requestStatus === 'failed') {
+            return;
+        }
+
+        // 实时计算首令延迟：首流事件前持续增长，首流事件后固定
+        const hasStreamStarted = state.streamStartTime !== undefined;
+        const latencyMs = hasStreamStarted
+            ? state.firstChunkLatencyMs
+            : Math.max(0, now - state.requestStartTime);
+
+        // 实时计算输出耗时：首流事件后开始计算
+        const durationMs = hasStreamStarted
+            ? Math.max(0, now - state.streamStartTime!)
+            : 0;
+
+        // 实时计算输出速度：outputChars / elapsedMs
+        const charsPerSecond = durationMs > 0 && state.outputChars > 0
+            ? (state.outputChars / durationMs) * 1000
+            : 0;
+
+        // 更新首令延迟 + 输出耗时 + 速度
+        const outputCell = targetRow.querySelector('td.records-output-merged[data-metric="output"]') as HTMLElement;
+        if (outputCell) {
+            const ttftSpan = outputCell.querySelector('.output-ttft') as HTMLElement;
+            if (ttftSpan) {
+                ttftSpan.textContent = latencyMs >= 1000 ?
+                    `${(latencyMs / 1000).toFixed(1)}s` :
+                    `${Math.round(latencyMs)}ms`;
+            }
+            const tpotSpan = outputCell.querySelector('.output-tpot') as HTMLElement;
+            if (tpotSpan) {
+                tpotSpan.textContent = durationMs > 0 ?
+                    (durationMs >= 1000 ? `${(durationMs / 1000).toFixed(1)}s` : `${Math.round(durationMs)}ms`) :
+                    '-';
+            }
+            // .output-tokens 在 streaming 阶段不更新，等最终 usage 回写
+            const speedSpan = outputCell.querySelector('.output-speed') as HTMLElement;
+            if (speedSpan) {
+                speedSpan.textContent = charsPerSecond > 0 ?
+                    `~${charsPerSecond.toFixed(1)} chars/s` : '-';
+                speedSpan.title = t(
+                    'Live speed is estimated by streamed characters; final speed uses output tokens.',
+                    '实时速度按流式字符估算，完成后以输出 token/s 为准。'
+                );
+            }
+        }
+    });
+}
+
+/**
  * 处理来自 VSCode 的消息
  */
 function handleVSCodeMessage(event: MessageEvent): void {
@@ -156,6 +346,8 @@ function handleVSCodeMessage(event: MessageEvent): void {
 
             if (dateChanged) {
                 resetRequestRecordsState();
+                liveMetricsMap.clear();
+                stopRenderClock();
             }
 
             setState({
@@ -174,12 +366,19 @@ function handleVSCodeMessage(event: MessageEvent): void {
                 }
             });
 
+            // setState 会重建表格，立即重新覆盖仍在运行的请求
+            updateRequestRecordsWithLiveMetrics();
+
             // 仅在真正切换日期时，小屏模式才自动隐藏侧边栏
             if (dateChanged && shouldCollapseSidebar()) {
                 toggleSidebar(false);
             }
             break;
         }
+
+        case 'updateLiveMetrics':
+            handleLiveMetricsUpdate(message.event);
+            break;
     }
 }
 

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -452,6 +452,7 @@ function updateRequestRecordsWithLiveMetrics(): void {
         if (outputCell) {
             const ttftSpan = outputCell.querySelector('.output-ttft') as HTMLElement;
             if (ttftSpan) {
+                ttftSpan.title = '首流延迟：从 provider 开始处理请求到首个流事件的近似耗时，不一定是首个可见文字';
                 ttftSpan.textContent = latencyMs >= 1000 ?
                     `${(latencyMs / 1000).toFixed(1)}s` :
                     `${Math.round(latencyMs)}ms`;

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -13,7 +13,11 @@ import { createElement } from '../utils';
 // 导入组件
 import { createSidebar, updateDateList } from './components/dateList';
 import { createMainContent, updateMainContent } from './components/mainContent';
-import { createRequestRecordsSection, createRequestRecordsTable, resetRequestRecordsState } from './components/requestRecords';
+import {
+    createRequestRecordsSection,
+    createRequestRecordsTable,
+    resetRequestRecordsState
+} from './components/requestRecords';
 
 // ============= 全局状态管理 =============
 
@@ -139,6 +143,7 @@ interface LiveMetricsState {
     lastOutputChangeAt: number; // 最后一次 provider 可计数字符增加的时间
     providerName?: string;
     modelName?: string;
+    hasFirstChunk?: boolean; // 首令延迟/流开始时间已固定（retry 幂等）
 }
 
 // 支持多个并发请求的实时指标状态
@@ -191,7 +196,8 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 charsPerSecond: 0,
                 lastOutputChangeAt: 0,
                 providerName: event.providerName,
-                modelName: event.modelName
+                modelName: event.modelName,
+                hasFirstChunk: false
             });
             startRenderClock();
             break;
@@ -208,8 +214,17 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 modelName: event.modelName
             };
             chunkState.requestStartTime = event.requestStartTime;
-            chunkState.streamStartTime = event.streamStartTime;
-            chunkState.firstChunkLatencyMs = event.firstChunkLatencyMs ?? 0;
+            // 幂等：retry 会创建新 StreamReporter 并再次触发 firstChunk，
+            // 只在首次设置 streamStartTime / firstChunkLatencyMs，避免后续重试覆盖真实值
+            if (!chunkState.hasFirstChunk) {
+                chunkState.streamStartTime = event.streamStartTime;
+                chunkState.firstChunkLatencyMs =
+                    event.firstChunkLatencyMs ??
+                    (event.streamStartTime !== undefined ?
+                        Math.max(0, event.streamStartTime - event.requestStartTime)
+                    :   0);
+                chunkState.hasFirstChunk = true;
+            }
             chunkState.providerName = chunkState.providerName || event.providerName;
             chunkState.modelName = chunkState.modelName || event.modelName;
             liveMetricsMap.set(requestId, chunkState);
@@ -222,13 +237,13 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             if (!state) {
                 state = {
                     requestStartTime: event.requestStartTime,
-                    streamStartTime: event.streamStartTime,
-                    firstChunkLatencyMs: event.firstChunkLatencyMs ?? 0,
                     outputChars: 0,
                     charsPerSecond: 0,
                     lastOutputChangeAt: 0,
                     providerName: event.providerName,
-                    modelName: event.modelName
+                    modelName: event.modelName,
+                    firstChunkLatencyMs: 0,
+                    hasFirstChunk: false
                 };
                 liveMetricsMap.set(requestId, state);
                 startRenderClock();
@@ -244,11 +259,13 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             // 补齐 provider/model（requestStarted 可能未被 WebView 接收到）
             state.providerName = state.providerName || event.providerName;
             state.modelName = state.modelName || event.modelName;
-            if (event.streamStartTime !== undefined) {
+            // 首令延迟/流开始时间：仅在尚未固定时从 streamingUpdate 补充
+            // （正常流程由 firstChunk 固定，streamingUpdate 仅作首次丢失的 fallback）
+            if (!state.hasFirstChunk && event.streamStartTime !== undefined) {
                 state.streamStartTime = event.streamStartTime;
-            }
-            if (event.firstChunkLatencyMs !== undefined) {
-                state.firstChunkLatencyMs = event.firstChunkLatencyMs;
+                state.firstChunkLatencyMs =
+                    event.firstChunkLatencyMs ?? Math.max(0, event.streamStartTime - event.requestStartTime);
+                state.hasFirstChunk = true;
             }
             break;
         }
@@ -278,8 +295,9 @@ function removeLivePlaceholderRow(requestId: string): void {
     if (!tbody) {
         return;
     }
-    const row = Array.from(tbody.querySelectorAll('tr'))
-        .find(r => r.getAttribute('data-request-id') === requestId) as HTMLTableRowElement | undefined;
+    const row = Array.from(tbody.querySelectorAll('tr')).find(r => r.getAttribute('data-request-id') === requestId) as
+        | HTMLTableRowElement
+        | undefined;
     if (row?.getAttribute('data-live-placeholder') === 'true') {
         row.remove();
         // 占位行删除后若表格为空，恢复"暂无请求记录"空行
@@ -338,8 +356,9 @@ function updateRequestRecordsWithLiveMetrics(): void {
     const hasSessionFilter = !!state.selectedSessionId;
 
     liveMetricsMap.forEach((metricState, requestId) => {
-        let targetRow = Array.from(tbody!.querySelectorAll('tr'))
-            .find(row => row.getAttribute('data-request-id') === requestId) as HTMLTableRowElement | undefined;
+        let targetRow = Array.from(tbody!.querySelectorAll('tr')).find(
+            row => row.getAttribute('data-request-id') === requestId
+        ) as HTMLTableRowElement | undefined;
 
         // 占位行：liveMetrics 已有数据但表格行尚未创建（updateDateDetails 尚未到达）
         if (!targetRow) {
@@ -419,14 +438,11 @@ function updateRequestRecordsWithLiveMetrics(): void {
 
         // 实时计算首令延迟：首流事件前持续增长，首流事件后固定
         const hasStreamStarted = metricState.streamStartTime !== undefined;
-        const latencyMs = hasStreamStarted
-            ? metricState.firstChunkLatencyMs
-            : Math.max(0, now - metricState.requestStartTime);
+        const latencyMs =
+            hasStreamStarted ? metricState.firstChunkLatencyMs : Math.max(0, now - metricState.requestStartTime);
 
         // 实时计算输出耗时：首流事件后开始计算
-        const durationMs = hasStreamStarted
-            ? Math.max(0, now - metricState.streamStartTime!)
-            : 0;
+        const durationMs = hasStreamStarted ? Math.max(0, now - metricState.streamStartTime!) : 0;
 
         // 输出速度：使用 StreamReporter 缓存的值，暂停期间不会衰减
         const charsPerSecond = metricState.charsPerSecond ?? 0;
@@ -500,7 +516,7 @@ function handleVSCodeMessage(event: MessageEvent): void {
                     sessionGroups.some(group => group.sessionId === state.selectedSessionId)
                 ) ?
                     state.selectedSessionId
-                    : null;
+                :   null;
 
             if (dateChanged) {
                 resetRequestRecordsState();

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -143,7 +143,7 @@ interface LiveMetricsState {
     lastOutputChangeAt: number; // 最后一次 provider 可计数字符增加的时间
     providerName?: string;
     modelName?: string;
-    hasFirstChunk?: boolean; // 首令延迟/流开始时间已固定（retry 幂等）
+    hasFirstChunk?: boolean; // 首流延迟/流开始时间已固定（retry 幂等）
 }
 
 // 支持多个并发请求的实时指标状态
@@ -188,19 +188,24 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
     const { requestId } = event;
 
     switch (event.type) {
-        case 'requestStarted':
+        case 'requestStarted': {
+            // requestStarted 在每次 retry attempt 都会触发。
+            // 保留首次 requestStartTime，使 live TTFT 与持久化记录口径一致；
+            // 重置 stream/output 状态，让当前 attempt 的输出耗时和速度重新开始。
+            const existing = liveMetricsMap.get(requestId);
             liveMetricsMap.set(requestId, {
-                requestStartTime: event.requestStartTime,
+                requestStartTime: existing?.requestStartTime || event.requestStartTime,
                 firstChunkLatencyMs: 0,
                 outputChars: 0,
                 charsPerSecond: 0,
                 lastOutputChangeAt: 0,
-                providerName: event.providerName,
-                modelName: event.modelName,
+                providerName: existing?.providerName || event.providerName,
+                modelName: existing?.modelName || event.modelName,
                 hasFirstChunk: false
             });
             startRenderClock();
             break;
+        }
 
         case 'firstChunk': {
             // upsert：requestStarted 可能因面板未打开/日期切换而丢失
@@ -213,15 +218,17 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 providerName: event.providerName,
                 modelName: event.modelName
             };
-            chunkState.requestStartTime = event.requestStartTime;
+            chunkState.requestStartTime = chunkState.requestStartTime || event.requestStartTime;
             // 每次 firstChunk 代表最新已产生首流事件的 attempt：
-            // 总是覆盖流开始时间和首令延迟，总是重置 per-attempt 输出状态
+            // 总是覆盖流开始时间和首流延迟，总是重置 per-attempt 输出状态。
+            // requestStartTime 保留首次值，firstChunkLatencyMs 用保留值重算以保持口径一致。
             chunkState.streamStartTime = event.streamStartTime;
             chunkState.firstChunkLatencyMs =
-                event.firstChunkLatencyMs ??
-                (event.streamStartTime !== undefined ?
-                    Math.max(0, event.streamStartTime - event.requestStartTime)
-                    : 0);
+                Number.isFinite(event.streamStartTime) &&
+                Number.isFinite(chunkState.requestStartTime) &&
+                chunkState.requestStartTime > 0 ?
+                    Math.max(0, event.streamStartTime! - chunkState.requestStartTime)
+                    : (event.firstChunkLatencyMs ?? 0);
             chunkState.outputChars = 0;
             chunkState.charsPerSecond = 0;
             chunkState.lastOutputChangeAt = 0;
@@ -249,7 +256,9 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 liveMetricsMap.set(requestId, state);
                 startRenderClock();
             }
-            state.requestStartTime = event.requestStartTime;
+            // 保留首次 requestStartTime（retry 时使 TTFT 口径接近持久化记录）
+            const effectiveRequestStartTime = state.requestStartTime || event.requestStartTime;
+            state.requestStartTime = effectiveRequestStartTime;
             // 检测 attempt 切换（firstChunk 丢失时的兜底）：
             // 通过 streamStartTime 变化判断是否换了新 attempt
             const isNewAttempt =
@@ -259,8 +268,11 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             if (isNewAttempt) {
                 state.streamStartTime = event.streamStartTime!;
                 state.firstChunkLatencyMs =
-                    event.firstChunkLatencyMs ??
-                    Math.max(0, event.streamStartTime! - event.requestStartTime);
+                    Number.isFinite(event.streamStartTime) &&
+                    Number.isFinite(effectiveRequestStartTime) &&
+                    effectiveRequestStartTime > 0 ?
+                        Math.max(0, event.streamStartTime! - effectiveRequestStartTime)
+                        : (event.firstChunkLatencyMs ?? 0);
                 state.outputChars = 0;
                 state.charsPerSecond = 0;
                 state.lastOutputChangeAt = 0;
@@ -269,7 +281,11 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 // 首次丢失 fallback：streamStartTime 未变但尚未固定首流
                 state.streamStartTime = event.streamStartTime;
                 state.firstChunkLatencyMs =
-                    event.firstChunkLatencyMs ?? Math.max(0, event.streamStartTime - event.requestStartTime);
+                    Number.isFinite(event.streamStartTime) &&
+                    Number.isFinite(effectiveRequestStartTime) &&
+                    effectiveRequestStartTime > 0 ?
+                        Math.max(0, event.streamStartTime - effectiveRequestStartTime)
+                        : (event.firstChunkLatencyMs ?? 0);
                 state.hasFirstChunk = true;
             }
 
@@ -476,7 +492,7 @@ function updateRequestRecordsWithLiveMetrics(): void {
             return;
         }
 
-        // 实时计算首令延迟：首流事件前持续增长，首流事件后固定
+        // 实时计算首流延迟：首流事件前持续增长，首流事件后固定
         const hasStreamStarted = metricState.streamStartTime !== undefined;
         const latencyMs =
             hasStreamStarted ? metricState.firstChunkLatencyMs : Math.max(0, now - metricState.requestStartTime);
@@ -487,7 +503,7 @@ function updateRequestRecordsWithLiveMetrics(): void {
         // 输出速度：使用 StreamReporter 缓存的值，暂停期间不会衰减
         const charsPerSecond = metricState.charsPerSecond ?? 0;
 
-        // 更新首令延迟 + 输出耗时 + 速度
+        // 更新首流延迟 + 输出耗时 + 速度
         const outputCell = targetRow.querySelector('td.records-output-merged[data-metric="output"]') as HTMLElement;
         if (outputCell) {
             // 防御性兜底：兼容旧 DOM 或未来变更，确保 span 结构存在

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -13,7 +13,7 @@ import { createElement } from '../utils';
 // 导入组件
 import { createSidebar, updateDateList } from './components/dateList';
 import { createMainContent, updateMainContent } from './components/mainContent';
-import { createRequestRecordsSection, resetRequestRecordsState } from './components/requestRecords';
+import { createRequestRecordsSection, createRequestRecordsTable, resetRequestRecordsState } from './components/requestRecords';
 
 // ============= 全局状态管理 =============
 
@@ -135,6 +135,8 @@ interface LiveMetricsState {
     streamStartTime?: number;
     firstChunkLatencyMs: number;
     outputChars: number;
+    providerName?: string;
+    modelName?: string;
 }
 
 // 支持多个并发请求的实时指标状态
@@ -183,7 +185,9 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             liveMetricsMap.set(requestId, {
                 requestStartTime: event.requestStartTime,
                 firstChunkLatencyMs: 0,
-                outputChars: 0
+                outputChars: 0,
+                providerName: event.providerName,
+                modelName: event.modelName
             });
             startRenderClock();
             break;
@@ -193,11 +197,15 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             const chunkState = liveMetricsMap.get(requestId) ?? {
                 requestStartTime: event.requestStartTime,
                 firstChunkLatencyMs: 0,
-                outputChars: 0
+                outputChars: 0,
+                providerName: event.providerName,
+                modelName: event.modelName
             };
             chunkState.requestStartTime = event.requestStartTime;
             chunkState.streamStartTime = event.streamStartTime;
             chunkState.firstChunkLatencyMs = event.firstChunkLatencyMs ?? 0;
+            chunkState.providerName = chunkState.providerName || event.providerName;
+            chunkState.modelName = chunkState.modelName || event.modelName;
             liveMetricsMap.set(requestId, chunkState);
             startRenderClock();
             break;
@@ -210,13 +218,18 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                     requestStartTime: event.requestStartTime,
                     streamStartTime: event.streamStartTime,
                     firstChunkLatencyMs: event.firstChunkLatencyMs ?? 0,
-                    outputChars: 0
+                    outputChars: 0,
+                    providerName: event.providerName,
+                    modelName: event.modelName
                 };
                 liveMetricsMap.set(requestId, state);
                 startRenderClock();
             }
             state.requestStartTime = event.requestStartTime;
             state.outputChars = event.outputChars ?? 0;
+            // 补齐 provider/model（requestStarted 可能未被 WebView 接收到）
+            state.providerName = state.providerName || event.providerName;
+            state.modelName = state.modelName || event.modelName;
             if (event.streamStartTime !== undefined) {
                 state.streamStartTime = event.streamStartTime;
             }
@@ -227,6 +240,7 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
         }
 
         case 'streamEnd': {
+            removeLivePlaceholderRow(requestId);
             liveMetricsMap.delete(requestId);
             if (liveMetricsMap.size === 0) {
                 stopRenderClock();
@@ -241,28 +255,146 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
 }
 
 /**
+ * 清理由实时指标创建的临时占位行（streamEnd 时调用）
+ * 仅删除标记为 data-live-placeholder 的行，不误删由 updateDateDetails 渲染的真实记录行
+ */
+function removeLivePlaceholderRow(requestId: string): void {
+    const recordsContainer = document.querySelector('#records-container') as HTMLElement | null;
+    const tbody = recordsContainer?.querySelector('tbody');
+    if (!tbody) {
+        return;
+    }
+    const row = Array.from(tbody.querySelectorAll('tr'))
+        .find(r => r.getAttribute('data-request-id') === requestId) as HTMLTableRowElement | undefined;
+    if (row?.getAttribute('data-live-placeholder') === 'true') {
+        row.remove();
+        // 占位行删除后若表格为空，恢复"暂无请求记录"空行
+        if (!tbody.querySelector('tr')) {
+            const emptyRow = document.createElement('tr');
+            const emptyCell = document.createElement('td');
+            emptyCell.colSpan = 10;
+            emptyCell.textContent = t('No request records yet', '暂无请求记录');
+            emptyCell.style.textAlign = 'center';
+            emptyRow.appendChild(emptyCell);
+            tbody.appendChild(emptyRow);
+        }
+    }
+}
+
+/**
+ * 判断当前是否在查看今天的请求记录（实时指标仅适用于今天）
+ */
+function isViewingToday(): boolean {
+    const today = state.today || getTodayDateString();
+    return state.dateDetails?.isToday === true || state.dateDetails?.date === today;
+}
+
+/**
  * 更新请求记录区域，显示实时指标
  * 策略：遍历所有正在流式的请求，通过 requestId 精确匹配表格行并更新
  */
 function updateRequestRecordsWithLiveMetrics(): void {
+    // 仅在今天页面渲染实时指标，不污染历史日期
+    if (!isViewingToday()) {
+        return;
+    }
+
     const recordsContainer = document.querySelector('#records-container') as HTMLElement;
     if (!recordsContainer) {
         return;
     }
 
-    const tbody = recordsContainer.querySelector('tbody');
+    let tbody = recordsContainer.querySelector('tbody');
     if (!tbody) {
-        return;
+        // 无 tbody（当天无记录），替换 .empty-message 为标准空表格，保留外层布局
+        const emptyMessage = recordsContainer.querySelector('.empty-message');
+        if (!emptyMessage) {
+            return;
+        }
+        const table = createRequestRecordsTable([], []);
+        emptyMessage.replaceWith(table);
+        tbody = table.querySelector('tbody');
+        if (!tbody) {
+            return;
+        }
     }
 
     const now = Date.now();
+    // 有会话筛选时，新请求可能不属于当前会话，不创建占位行（真实行仍可更新）
+    const hasSessionFilter = !!state.selectedSessionId;
 
-    liveMetricsMap.forEach((state, requestId) => {
-        const targetRow = Array.from(tbody.querySelectorAll('tr'))
+    liveMetricsMap.forEach((metricState, requestId) => {
+        let targetRow = Array.from(tbody!.querySelectorAll('tr'))
             .find(row => row.getAttribute('data-request-id') === requestId) as HTMLTableRowElement | undefined;
 
+        // 占位行：liveMetrics 已有数据但表格行尚未创建（updateDateDetails 尚未到达）
         if (!targetRow) {
-            return;
+            // 有会话筛选时，新请求不属于当前会话，跳过占位行创建
+            if (hasSessionFilter) {
+                return;
+            }
+            targetRow = document.createElement('tr');
+            targetRow.setAttribute('data-request-id', requestId);
+            targetRow.setAttribute('data-request-status', 'streaming');
+            targetRow.setAttribute('data-live-placeholder', 'true');
+
+            // 时间
+            const timeCell = document.createElement('td');
+            timeCell.textContent = new Date(metricState.requestStartTime).toLocaleTimeString('zh-CN');
+            targetRow.appendChild(timeCell);
+
+            // 提供商
+            const providerCell = document.createElement('td');
+            providerCell.textContent = metricState.providerName || '-';
+            targetRow.appendChild(providerCell);
+
+            // 模型
+            const modelCell = document.createElement('td');
+            modelCell.textContent = metricState.modelName || '-';
+            targetRow.appendChild(modelCell);
+
+            // 输入令牌
+            const inputCell = document.createElement('td');
+            inputCell.textContent = '-';
+            targetRow.appendChild(inputCell);
+
+            // 缓存命中
+            const cacheCell = document.createElement('td');
+            cacheCell.textContent = '-';
+            targetRow.appendChild(cacheCell);
+
+            // 输出令牌
+            const outputCell = document.createElement('td');
+            outputCell.textContent = '-';
+            targetRow.appendChild(outputCell);
+
+            // 消耗令牌
+            const totalCell = document.createElement('td');
+            totalCell.textContent = '-';
+            targetRow.appendChild(totalCell);
+
+            // 首令延迟 + 输出耗时
+            const timingCell = document.createElement('td');
+            timingCell.setAttribute('data-metric', 'timing');
+            targetRow.appendChild(timingCell);
+
+            // 输出速度
+            const speedCell = document.createElement('td');
+            speedCell.setAttribute('data-metric', 'speed');
+            targetRow.appendChild(speedCell);
+
+            // 状态
+            const statusCell = document.createElement('td');
+            statusCell.className = 'status-estimated';
+            statusCell.textContent = '⏳';
+            targetRow.appendChild(statusCell);
+
+            // 移除空状态行（如 "暂无请求记录"）并插入占位行
+            const firstRow = tbody!.querySelector('tr');
+            if (firstRow && firstRow.querySelector('td[colspan]')) {
+                firstRow.remove();
+            }
+            tbody!.insertBefore(targetRow, tbody!.firstChild);
         }
 
         // 跳过已完成/失败的行，避免实时值覆盖最终统计
@@ -272,19 +404,19 @@ function updateRequestRecordsWithLiveMetrics(): void {
         }
 
         // 实时计算首令延迟：首流事件前持续增长，首流事件后固定
-        const hasStreamStarted = state.streamStartTime !== undefined;
+        const hasStreamStarted = metricState.streamStartTime !== undefined;
         const latencyMs = hasStreamStarted
-            ? state.firstChunkLatencyMs
-            : Math.max(0, now - state.requestStartTime);
+            ? metricState.firstChunkLatencyMs
+            : Math.max(0, now - metricState.requestStartTime);
 
         // 实时计算输出耗时：首流事件后开始计算
         const durationMs = hasStreamStarted
-            ? Math.max(0, now - state.streamStartTime!)
+            ? Math.max(0, now - metricState.streamStartTime!)
             : 0;
 
         // 实时计算输出速度：outputChars / elapsedMs
-        const charsPerSecond = durationMs > 0 && state.outputChars > 0
-            ? (state.outputChars / durationMs) * 1000
+        const charsPerSecond = durationMs > 0 && metricState.outputChars > 0
+            ? (metricState.outputChars / durationMs) * 1000
             : 0;
 
         // 更新首令延迟 + 输出耗时 + 速度
@@ -342,12 +474,16 @@ function handleVSCodeMessage(event: MessageEvent): void {
                     sessionGroups.some(group => group.sessionId === state.selectedSessionId)
                 ) ?
                     state.selectedSessionId
-                :   null;
+                    : null;
 
             if (dateChanged) {
                 resetRequestRecordsState();
-                liveMetricsMap.clear();
-                stopRenderClock();
+                // 切到非今天时停止实时渲染；切到今天时保留正在进行的 liveMetrics，
+                // 避免 requestStarted 先到达后被 updateDateDetails 清空导致 TTFT 不显示
+                if (!message.isToday) {
+                    liveMetricsMap.clear();
+                    stopRenderClock();
+                }
             }
 
             setState({

--- a/src/ui/usagesView/app.ts
+++ b/src/ui/usagesView/app.ts
@@ -155,11 +155,11 @@ let renderClockId: number | undefined;
 let lastRenderAt = 0;
 
 function startRenderClock(): void {
-    if (renderClockId !== undefined) {
+    if (!isViewingToday() || liveMetricsMap.size === 0 || renderClockId !== undefined) {
         return;
     }
     const tick = (frameTime: number): void => {
-        if (liveMetricsMap.size === 0) {
+        if (!isViewingToday() || liveMetricsMap.size === 0) {
             renderClockId = undefined;
             lastRenderAt = 0;
             return;
@@ -214,22 +214,18 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 modelName: event.modelName
             };
             chunkState.requestStartTime = event.requestStartTime;
-            // 幂等：retry 会创建新 StreamReporter 并再次触发 firstChunk，
-            // 只在首次设置 streamStartTime / firstChunkLatencyMs，避免后续重试覆盖真实值
-            if (!chunkState.hasFirstChunk) {
-                chunkState.streamStartTime = event.streamStartTime;
-                chunkState.firstChunkLatencyMs =
-                    event.firstChunkLatencyMs ??
-                    (event.streamStartTime !== undefined ?
-                        Math.max(0, event.streamStartTime - event.requestStartTime)
-                        : 0);
-                chunkState.hasFirstChunk = true;
-            } else {
-                // retry/new reporter: keep original firstChunkLatencyMs, reset per-attempt output state
-                chunkState.outputChars = 0;
-                chunkState.charsPerSecond = 0;
-                chunkState.lastOutputChangeAt = 0;
-            }
+            // 每次 firstChunk 代表最新已产生首流事件的 attempt：
+            // 总是覆盖流开始时间和首令延迟，总是重置 per-attempt 输出状态
+            chunkState.streamStartTime = event.streamStartTime;
+            chunkState.firstChunkLatencyMs =
+                event.firstChunkLatencyMs ??
+                (event.streamStartTime !== undefined ?
+                    Math.max(0, event.streamStartTime - event.requestStartTime)
+                    : 0);
+            chunkState.outputChars = 0;
+            chunkState.charsPerSecond = 0;
+            chunkState.lastOutputChangeAt = 0;
+            chunkState.hasFirstChunk = true;
             chunkState.providerName = chunkState.providerName || event.providerName;
             chunkState.modelName = chunkState.modelName || event.modelName;
             liveMetricsMap.set(requestId, chunkState);
@@ -254,6 +250,29 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
                 startRenderClock();
             }
             state.requestStartTime = event.requestStartTime;
+            // 检测 attempt 切换（firstChunk 丢失时的兜底）：
+            // 通过 streamStartTime 变化判断是否换了新 attempt
+            const isNewAttempt =
+                event.streamStartTime !== undefined &&
+                event.streamStartTime !== state.streamStartTime;
+
+            if (isNewAttempt) {
+                state.streamStartTime = event.streamStartTime!;
+                state.firstChunkLatencyMs =
+                    event.firstChunkLatencyMs ??
+                    Math.max(0, event.streamStartTime! - event.requestStartTime);
+                state.outputChars = 0;
+                state.charsPerSecond = 0;
+                state.lastOutputChangeAt = 0;
+                state.hasFirstChunk = true;
+            } else if (!state.hasFirstChunk && event.streamStartTime !== undefined) {
+                // 首次丢失 fallback：streamStartTime 未变但尚未固定首流
+                state.streamStartTime = event.streamStartTime;
+                state.firstChunkLatencyMs =
+                    event.firstChunkLatencyMs ?? Math.max(0, event.streamStartTime - event.requestStartTime);
+                state.hasFirstChunk = true;
+            }
+
             // 只在 outputChars 实际增加时更新 lastOutputChangeAt（避免 heartbeat/ping 误刷新）
             const previousOutputChars = state.outputChars;
             if (event.outputChars !== undefined && event.outputChars > previousOutputChars) {
@@ -264,14 +283,6 @@ function handleLiveMetricsUpdate(event: LiveStreamMetricEvent): void {
             // 补齐 provider/model（requestStarted 可能未被 WebView 接收到）
             state.providerName = state.providerName || event.providerName;
             state.modelName = state.modelName || event.modelName;
-            // 首令延迟/流开始时间：仅在尚未固定时从 streamingUpdate 补充
-            // （正常流程由 firstChunk 固定，streamingUpdate 仅作首次丢失的 fallback）
-            if (!state.hasFirstChunk && event.streamStartTime !== undefined) {
-                state.streamStartTime = event.streamStartTime;
-                state.firstChunkLatencyMs =
-                    event.firstChunkLatencyMs ?? Math.max(0, event.streamStartTime - event.requestStartTime);
-                state.hasFirstChunk = true;
-            }
             break;
         }
 
@@ -515,8 +526,8 @@ function updateRequestRecordsWithLiveMetrics(): void {
                 } else if (charsPerSecond > 0) {
                     speedSpan.textContent = `~${charsPerSecond.toFixed(1)} chars/s`;
                     speedSpan.title = t(
-                        'Live speed is estimated by streamed characters; final speed uses output tokens.',
-                        '实时速度按流式字符估算，完成后以输出 token/s 为准。'
+                        'Average character rate from the first stream event to the latest output of the current attempt; completed requests show usage-based output tokens/s.',
+                        '累计平均字符速度：按当前尝试从首个流事件到最近一次输出的字符总量估算；请求完成后显示基于 usage 的输出 token/s。'
                     );
                 } else {
                     speedSpan.textContent = '-';
@@ -556,10 +567,9 @@ function handleVSCodeMessage(event: MessageEvent): void {
 
             if (dateChanged) {
                 resetRequestRecordsState();
-                // 切到非今天时停止实时渲染；切到今天时保留正在进行的 liveMetrics，
-                // 避免 requestStarted 先到达后被 updateDateDetails 清空导致 TTFT 不显示
+                // 切到非今天时停止实时渲染时钟，但保留 liveMetricsMap 中的活动状态；
+                // 切回今天时由 startRenderClock() 内部的 isViewingToday() 守卫自动恢复
                 if (!message.isToday) {
-                    liveMetricsMap.clear();
                     stopRenderClock();
                 }
             }
@@ -580,8 +590,11 @@ function handleVSCodeMessage(event: MessageEvent): void {
                 }
             });
 
-            // setState 会重建表格，立即重新覆盖仍在运行的请求
+            // 先立即重建表格（包括仍在运行的请求），再按需启动渲染时钟
             updateRequestRecordsWithLiveMetrics();
+            if (message.isToday && liveMetricsMap.size > 0) {
+                startRenderClock();
+            }
 
             // 仅在真正切换日期时，小屏模式才自动隐藏侧边栏
             if (dateChanged && shouldCollapseSidebar()) {

--- a/src/ui/usagesView/components/requestRecords.ts
+++ b/src/ui/usagesView/components/requestRecords.ts
@@ -362,7 +362,7 @@ function createRequestRecordsTable(
     const tbody = createElement('tbody');
     if (records.length === 0) {
         const emptyRow = createElement('tr');
-        const emptyCell = createElement('td', '', { colSpan: 7 });
+        const emptyCell = createElement('td', '', { colSpan: 6 });
         emptyCell.textContent = t('No request records yet', '暂无请求记录');
         emptyCell.style.textAlign = 'center';
         emptyRow.appendChild(emptyCell);
@@ -373,6 +373,12 @@ function createRequestRecordsTable(
 
     records.forEach(record => {
         const row = createElement('tr');
+        // 存储请求ID和状态，用于实时指标精确匹配
+        if (record.requestId) {
+            row.setAttribute('data-request-id', record.requestId);
+        }
+        row.setAttribute('data-request-status', record.status);
+
         const time = createElement('td');
         const timeStr = record.timestamp ? new Date(record.timestamp).toLocaleTimeString('zh-CN') : '-';
         const kindName = getRequestKindDisplayName(record.requestKind);
@@ -413,8 +419,9 @@ function createRequestRecordsTable(
             input.title = inputVal.toLocaleString('en-US');
         }
 
-        // 合并输出列：上行 TTFT | 输出令牌，下行 OTFT | 输出速度
+        // 合并输出列：上行 TTFT | 输出令牌，下行 TPOT | 输出速度
         const output = createElement('td', 'records-output-merged');
+        output.setAttribute('data-metric', 'output');
         const outputVal = record.status === 'completed' && record.outputTokens > 0 ? record.outputTokens : 0;
         const ttft =
             (

--- a/src/ui/usagesView/components/requestRecords.ts
+++ b/src/ui/usagesView/components/requestRecords.ts
@@ -334,8 +334,9 @@ function appendTotalsRow(tbody: HTMLElement, summaryRecords: ExtendedTokenReques
 
 /**
  * 创建请求记录表格，并在底部展示当前会话/全部会话的汇总行
+ * 同时被 createRequestRecordsSection 和 app.ts 的实时指标占位逻辑复用
  */
-function createRequestRecordsTable(
+export function createRequestRecordsTable(
     records: ExtendedTokenRequestLog[],
     summaryRecords: ExtendedTokenRequestLog[]
 ): HTMLElement {

--- a/src/ui/usagesView/components/requestRecords.ts
+++ b/src/ui/usagesView/components/requestRecords.ts
@@ -395,7 +395,11 @@ export function createRequestRecordsTable(
         const provName = getProviderDisplayName(record.providerKey, record.providerName) || '-';
         const modName = record.modelName || '-';
         providerModel.title = `${provName} · ${modName}`;
-        providerModel.innerHTML = `<div class="prov-model-provider">${provName}</div><div class="prov-model-model">${modName}</div>`;
+        const providerDiv = createElement('div', 'prov-model-provider');
+        providerDiv.textContent = provName;
+        const modelDiv = createElement('div', 'prov-model-model');
+        modelDiv.textContent = modName;
+        providerModel.append(providerDiv, modelDiv);
 
         const input = createElement('td', 'records-input-merged');
         const isCompleted = record.status === 'completed' && record.rawUsage && record.totalTokens > 0;
@@ -437,26 +441,24 @@ export function createRequestRecordsTable(
         const tpot =
             record.streamDuration !== undefined && record.streamDuration > 0 ? record.streamDuration : undefined;
 
-        if (ttft !== undefined || outputVal > 0) {
-            const ttftText =
-                ttft !== undefined ?
-                    ttft >= 1000 ?
-                        `${(ttft / 1000).toFixed(1)}s`
-                    :   `${Math.round(ttft)}ms`
-                :   '-';
-            const tpotText =
-                tpot !== undefined ?
-                    tpot >= 1000 ?
-                        `${(tpot / 1000).toFixed(1)}s`
-                    :   `${Math.round(tpot)}ms`
-                :   '-';
-            const speedText = speedVal !== undefined ? `${speedVal.toFixed(1)} t/s` : '-';
-            output.innerHTML =
-                `<div class="output-row"><span class="output-ttft" title="TTFT: ${ttft !== undefined ? ttft.toLocaleString('en-US') + 'ms' : '-'}">${ttftText}</span><span class="output-tokens" title="Output tokens: ${outputVal.toLocaleString('en-US')}">${formatTokens(outputVal)}</span></div>` +
-                `<div class="output-detail"><span class="output-tpot" title="TPOT: ${tpot !== undefined ? tpot.toLocaleString('en-US') + 'ms' : '-'}">${tpotText}</span><span class="output-speed" title="Speed: ${speedText}">${speedText}</span></div>`;
-        } else {
-            output.textContent = outputVal > 0 ? formatTokens(outputVal) : '-';
-        }
+        const ttftText =
+            ttft !== undefined ?
+                ttft >= 1000 ?
+                    `${(ttft / 1000).toFixed(1)}s`
+                :   `${Math.round(ttft)}ms`
+            :   '-';
+        const tpotText =
+            tpot !== undefined ?
+                tpot >= 1000 ?
+                    `${(tpot / 1000).toFixed(1)}s`
+                :   `${Math.round(tpot)}ms`
+            :   '-';
+        const speedText = speedVal !== undefined ? `${speedVal.toFixed(1)} t/s` : '-';
+        const outputTokensText = outputVal > 0 ? formatTokens(outputVal) : '-';
+        const outputTokensTitle = outputVal > 0 ? outputVal.toLocaleString('en-US') : '-';
+        output.innerHTML =
+            `<div class="output-row"><span class="output-ttft" title="TTFT: ${ttft !== undefined ? ttft.toLocaleString('en-US') + 'ms' : '-'}">${ttftText}</span><span class="output-tokens" title="Output tokens: ${outputTokensTitle}">${outputTokensText}</span></div>` +
+            `<div class="output-detail"><span class="output-tpot" title="TPOT: ${tpot !== undefined ? tpot.toLocaleString('en-US') + 'ms' : '-'}">${tpotText}</span><span class="output-speed" title="Speed: ${speedText}">${speedText}</span></div>`;
         if (outputVal > 0) {
             output.title = outputVal.toLocaleString('en-US');
         }

--- a/src/ui/usagesView/index.ts
+++ b/src/ui/usagesView/index.ts
@@ -251,15 +251,11 @@ export class TokenUsagesView {
 
     /**
      * 处理实时流式指标事件，发送给 WebView 更新显示
+     * 不在 Extension 层过滤日期——WebView 端已有 isViewingToday() 控制是否渲染，
+     * 这样用户从历史日期切回今天时不会丢失正在进行的 live events。
      */
     private handleLiveMetricEvent(event: LiveStreamMetricEvent): void {
         if (!this.panel) {
-            return;
-        }
-
-        // 只在查看今日数据时发送实时更新
-        const today = getTodayDateString();
-        if (this.currentSelectedDate !== today) {
             return;
         }
 

--- a/src/ui/usagesView/index.ts
+++ b/src/ui/usagesView/index.ts
@@ -255,14 +255,28 @@ export class TokenUsagesView {
      * 这样用户从历史日期切回今天时不会丢失正在进行的 live events。
      */
     private handleLiveMetricEvent(event: LiveStreamMetricEvent): void {
-        if (!this.panel) {
+        const panel = this.panel;
+        if (!panel) {
             return;
         }
 
-        this.panel.webview.postMessage({
-            command: 'updateLiveMetrics',
-            event
-        } as UpdateLiveMetricsMessage);
+        try {
+            void panel.webview.postMessage({
+                command: 'updateLiveMetrics',
+                event
+            } as UpdateLiveMetricsMessage).then(
+                delivered => {
+                    if (!delivered) {
+                        StatusLogger.trace('[TokenUsagesView] live metric message dropped');
+                    }
+                },
+                err => {
+                    StatusLogger.warn('[TokenUsagesView] failed to post live metric message:', err);
+                }
+            );
+        } catch (err) {
+            StatusLogger.warn('[TokenUsagesView] failed to post live metric message:', err);
+        }
     }
 
     /**

--- a/src/ui/usagesView/index.ts
+++ b/src/ui/usagesView/index.ts
@@ -9,10 +9,11 @@ import * as path from 'path';
 import { TokenUsagesManager } from '../../usages/usagesManager';
 import { StatusLogger } from '../../utils/statusLogger';
 import { t } from '../../utils/l10n';
-import { UpdateDateDetailsMessage, UpdateDateListMessage } from './types';
+import { UpdateDateDetailsMessage, UpdateDateListMessage, UpdateLiveMetricsMessage } from './types';
 import type { WebViewMessage } from './types';
 import { getTodayDateString } from './utils';
 import { MultiDayView } from '../multiDayView';
+import { onLiveMetrics, type LiveStreamMetricEvent } from '../../metrics/liveMetrics';
 
 /**
  * Token 用量 WebView 视图
@@ -21,6 +22,7 @@ export class TokenUsagesView {
     private panel: vscode.WebviewPanel | undefined;
     private usagesManager: TokenUsagesManager;
     private updateDisposable: vscode.Disposable | undefined;
+    private liveMetricsDisposable: vscode.Disposable | undefined;
     private currentSelectedDate: string | undefined; // 当前查看的日期
     private hasCheckedOutdatedStats: boolean = false; // 是否已检查过过期统计
 
@@ -69,11 +71,21 @@ export class TokenUsagesView {
             }
         });
 
+        // 监听实时流式指标事件（retainContextWhenHidden 下隐藏面板仍可接收消息）
+        this.liveMetricsDisposable = onLiveMetrics((event: LiveStreamMetricEvent) => {
+            if (!this.panel) {
+                return;
+            }
+            this.handleLiveMetricEvent(event);
+        });
+
         // 监听关闭
         this.panel.onDidDispose(() => {
             this.panel = undefined;
             this.updateDisposable?.dispose();
             this.updateDisposable = undefined;
+            this.liveMetricsDisposable?.dispose();
+            this.liveMetricsDisposable = undefined;
         });
     }
 
@@ -235,6 +247,26 @@ export class TokenUsagesView {
                 this.showMultiDayTrend();
                 break;
         }
+    }
+
+    /**
+     * 处理实时流式指标事件，发送给 WebView 更新显示
+     */
+    private handleLiveMetricEvent(event: LiveStreamMetricEvent): void {
+        if (!this.panel) {
+            return;
+        }
+
+        // 只在查看今日数据时发送实时更新
+        const today = getTodayDateString();
+        if (this.currentSelectedDate !== today) {
+            return;
+        }
+
+        this.panel.webview.postMessage({
+            command: 'updateLiveMetrics',
+            event
+        } as UpdateLiveMetricsMessage);
     }
 
     /**

--- a/src/ui/usagesView/types.ts
+++ b/src/ui/usagesView/types.ts
@@ -12,6 +12,7 @@ import type {
     HourlyStats
 } from '../../usages/fileLogger/types';
 import type { ExtendedTokenRequestLog } from '../../usages/fileLogger/usageParser';
+import type { LiveStreamMetricEvent } from '../../metrics/liveMetrics';
 
 // ============= UI 层数据类型 =============
 
@@ -83,7 +84,15 @@ export interface UpdateDateDetailsMessage {
     records: ExtendedTokenRequestLog[];
 }
 
-export type HostMessage = UpdateDateListMessage | UpdateDateDetailsMessage;
+/**
+ * 实时流式指标更新消息
+ */
+export interface UpdateLiveMetricsMessage {
+    command: 'updateLiveMetrics';
+    event: LiveStreamMetricEvent;
+}
+
+export type HostMessage = UpdateDateListMessage | UpdateDateDetailsMessage | UpdateLiveMetricsMessage;
 
 // ============= 应用状态类型 =============
 


### PR DESCRIPTION
## 总结

为 Token 消耗统计面板增加实时流式指标展示能力，在请求仍在输出时即可看到首流延迟、输出耗时和实时输出速度，帮助更直观地判断不同模型 / 网关的响应表现。

该实现将实时指标作为轻量事件通道接入现有统计视图：流式请求开始后先创建实时占位行，首个流事件到达后固定首流延迟，流式输出过程中持续更新输出耗时与字符速度；请求完成后再由原有持久化 usage 统计刷新为最终 token 统计，避免实时值和最终值相互覆盖。

## 改动

* 新增 `liveMetrics` 轻量事件总线，用于在 `StreamReporter`、Provider 层和 Token Usage WebView 之间传递实时指标事件。
* 在 `StreamReporter` 中增加实时指标上报能力：

  * 上报 `firstChunk` / `streamingUpdate`。
  * 首流延迟在首个流事件后固定。
  * 输出速度基于真实收到的 provider 输出字符更新，避免流式暂停期间速度随时间持续衰减。
  * 工具调用参数增量也计入实时输出字符，避免工具调用场景下速度漏算。
* 将请求级实时指标生命周期下沉到统一请求执行入口：

  * `requestStarted` 在每次 retry attempt 开始时触发。
  * `streamEnd` 在整个重试流程结束后统一触发。
  * API Key 等待 / 授权时间不计入实时延迟。
* 覆盖多种 SDK / 网关路径：

  * OpenAI Chat Completions
  * OpenAI Responses
  * OpenAI compatible SSE
  * Anthropic compatible
  * Gemini SSE
* 优化 Token Usage WebView 实时渲染：

  * 支持按 `requestId` 精确匹配并发请求。
  * 没有持久化记录时创建实时占位行。
  * 已完成 / 已失败行不会被实时数据覆盖。
  * 切换日期或隐藏面板时保留活动实时状态，切回今天后恢复渲染。
  * 流结束后将占位行标记为 finishing，并增加兜底清理，减少刷新前闪烁或残留。
* 调整请求记录表格结构：

  * 统一实时占位行、空状态行和正式记录行的列数。
  * 合并 Provider / Model 展示。
  * 输出列统一展示 TTFT、输出 token、输出耗时和速度。
  * 输出 token 为 0 时显示 `-`，避免误导为最终统计值。
* 统一“首流延迟”口径说明：

  * 当前指标表示 provider 开始处理请求到首个有效流事件的近似耗时。
  * 它不等同于严格意义上的网络请求发出到首个可见文字。
  
### 录屏说明

录屏展示了 Token 消耗统计面板中的实时指标效果：

https://github.com/user-attachments/assets/7462c102-52a0-45ce-98c6-1ae0ad6ccad9


* 实时行会展示输出耗时与输出速度的动态变化。
* 已完成请求显示最终令牌消耗与完成状态。
* 面板中可以同时看到实时请求与历史完成记录，验证实时占位行不会影响已完成记录展示。

### 测试说明

* 请求进行中可显示实时占位行。
* 输出耗时与输出速度会随流式响应更新。
* 已完成记录保持正常展示。
* 实时状态与最终 usage 统计可以自然衔接。











