### PR TITLE
fix: 视觉工具支持 compatible 提供商

### DIFF
--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -1253,25 +1253,12 @@ export class OpenAIHandler {
         const imageParts: vscode.LanguageModelDataPart[] = [];
         // 收集图片（如果支持）
         if (modelConfig?.capabilities?.imageInput === true) {
-            // Logger.debug('Model supports image input, collecting image parts');
             for (const part of message.content) {
                 if (part instanceof vscode.LanguageModelDataPart) {
-                    // Logger.debug(`📷 发现数据部分: MIME=${part.mimeType}, 大小=${part.data.length}字节`);
                     if (this.isImageMimeType(part.mimeType)) {
                         imageParts.push(part);
                         Logger.debug(`✅ Added image: MIME=${part.mimeType}, size=${part.data.length} bytes`);
-                    } else {
-                        // // 分类处理不同类型的数据
-                        // if (part.mimeType === 'cache_control') {
-                        //     Logger.trace('Ignoring Claude cache marker: cache_control');
-                        // } else if (part.mimeType.startsWith('image/')) {
-                        //     Logger.warn(`❌ 不支持的图像MIME类型: ${part.mimeType}`);
-                        // } else {
-                        //     Logger.trace(`📄 跳过非图像数据: ${part.mimeType}`);
-                        // }
                     }
-                } else {
-                    // Logger.trace(`📝 非数据部分: ${part.constructor.name}`);
                 }
             }
         }

--- a/src/tools/vision/provider.ts
+++ b/src/tools/vision/provider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Logger, ConfigManager } from '../../utils';
+import { Logger, ConfigManager, CompatibleModelManager } from '../../utils';
 
 /**
  * Vision 分析结果
@@ -60,16 +60,29 @@ export async function analyzeImagesWithSystem(
     }
 
     const providerConfigs = ConfigManager.getConfigProvider();
-    const baseConfig = providerConfigs[visionModel.provider as keyof typeof providerConfigs];
-    const effectiveConfig =
-        baseConfig ? ConfigManager.applyProviderOverrides(visionModel.provider, baseConfig) : undefined;
-    const matchedModel = effectiveConfig?.models.find(m => m.id === visionModel.model);
-    const actualProvider = matchedModel?.provider || visionModel.provider;
-    const fullModelId = `gcmp.${actualProvider}:::${visionModel.model}`;
     const allModels = await vscode.lm.selectChatModels({});
-    const model = allModels.find(m => m.id === fullModelId);
+    let model: vscode.LanguageModelChatInformation | undefined;
+
+    if (visionModel.provider === 'compatible') {
+        // compatible 提供商：使用 CompatibleModelManager 获取动态模型列表
+        const models = CompatibleModelManager.getModels();
+        const matched = models.find(m => m.id === visionModel.model);
+        const actualProvider = matched?.provider || 'compatible';
+        const fullModelId = `gcmp.${actualProvider}:::${visionModel.model}`;
+        model = allModels.find(m => m.id === fullModelId);
+    } else {
+        // 非 compatible：检查模型是否有独立的 provider 字段
+        const baseConfig = providerConfigs[visionModel.provider as keyof typeof providerConfigs];
+        const effectiveConfig =
+            baseConfig ? ConfigManager.applyProviderOverrides(visionModel.provider, baseConfig) : undefined;
+        const matchedModel = effectiveConfig?.models.find(m => m.id === visionModel.model);
+        const actualProvider = matchedModel?.provider || visionModel.provider;
+        const fullModelId = `gcmp.${actualProvider}:::${visionModel.model}`;
+        model = allModels.find(m => m.id === fullModelId);
+    }
+
     if (!model) {
-        throw new Error(`Vision model not found: ${fullModelId}. Please check gcmp.vision.model configuration.`);
+        throw new Error(`Vision model not found: gcmp.${visionModel.provider}:::${visionModel.model}. Please check gcmp.vision.model configuration.`);
     }
 
     const imageParts = filePaths.map(filePath => {


### PR DESCRIPTION
## 问题描述

视觉分析工具（如 `#gcmpExtractTextFromScreenshot`、`#gcmpAnalyzeImage` 等）在 `gcmp.vision.model.provider` 配置为 `compatible` 时，报错：

```
Vision model not found: gcmp.compatible:::<model-id>. Please check gcmp.vision.model configuration.
```

## 根因

`src/tools/vision/provider.ts` 中查找模型时仅使用 `ConfigManager.getConfigProvider()`，该方法返回内置 provider 配置（zhipu、minimax、dashscope 等），**不包含 compatible 提供商**。compatible 提供商的模型由用户通过 `gcmp.compatibleModels` 动态配置，需要通过 `CompatibleModelManager.getModels()` 获取。

此外，compatible 提供商的模型 ID 格式为 `gcmp.<model.provider>:::<model.id>`，其中 `model.provider` 可能为 `OpenAI` 等自定义值（非 `compatible`），因此需要从模型配置中读取实际的 `provider` 字段来构造正确的 model ID。

## 解决方案

当 `visionModel.provider === 'compatible'` 时，使用 `CompatibleModelManager.getModels()` 查找模型并获取实际的 `provider` 字段，与 `src/commit/generatorService.ts` 中已有的处理方式保持一致。

非 compatible 路径的查找逻辑保持不变。

## 变更内容

| 文件 | 改动 |
|------|------|
| `src/tools/vision/provider.ts` | 新增 `provider === 'compatible'` 分支，使用 `CompatibleModelManager.getModels()` 查找模型 |
| `src/handlers/openaiHandler.ts` | 清理 `convertUserContentMessage` 中已注释的废弃日志代码 |

## 测试

- 配置 `gcmp.vision.model` 为 `{ "provider": "compatible", "model": "<compatible-model-id>" }`
- 调用视觉分析工具（如 `#gcmpExtractTextFromScreenshot`）分析图片
- 确认工具正常返回图片分析结果，不再报 "Vision model not found"
- 非 compatible 提供商（如 zhipu）的视觉工具功能不受影响