### PR TITLE
fix(usages-view): 修复中途打开面板时实时指标丢失

### DIFF
--- a/src/handlers/liveMetrics.test.ts
+++ b/src/handlers/liveMetrics.test.ts
@@ -14,19 +14,17 @@ function makeEvent(overrides: Partial<LiveStreamMetricEvent> = {}): LiveStreamMe
     };
 }
 
-// 每个测试前清空快照（通过 streamEnd 清理所有已知 requestId）
-// 由于 activeMetrics 是模块私有的，通过 emit streamEnd 清理
-function cleanupSnapshot(requestIds: string[]): void {
-    for (const id of requestIds) {
-        emitLiveMetrics(makeEvent({ type: 'streamEnd', requestId: id }));
+/** 动态清理所有活跃快照，避免固定 requestId 列表遗漏 */
+function cleanupAllSnapshots(): void {
+    for (const event of getActiveMetricsSnapshot()) {
+        emitLiveMetrics(makeEvent({ type: 'streamEnd', requestId: event.requestId }));
     }
 }
 
 test('emitLiveMetrics updates snapshot even when no listeners exist', () => {
-    cleanupSnapshot(['req-no-listener']);
+    cleanupAllSnapshots();
     const event = makeEvent({ requestId: 'req-no-listener', type: 'requestStarted' });
 
-    // 无 listener 时 emit
     emitLiveMetrics(event);
 
     const snapshot = getActiveMetricsSnapshot();
@@ -34,11 +32,11 @@ test('emitLiveMetrics updates snapshot even when no listeners exist', () => {
     assert.ok(found, 'snapshot should contain the event even without listeners');
     assert.equal(found.type, 'requestStarted');
 
-    cleanupSnapshot(['req-no-listener']);
+    cleanupAllSnapshots();
 });
 
 test('streamEnd removes requestId from snapshot', () => {
-    cleanupSnapshot(['req-end']);
+    cleanupAllSnapshots();
     emitLiveMetrics(makeEvent({ requestId: 'req-end', type: 'streamingUpdate' }));
 
     let snapshot = getActiveMetricsSnapshot();
@@ -51,7 +49,7 @@ test('streamEnd removes requestId from snapshot', () => {
 });
 
 test('snapshot is updated to latest event for the same requestId', () => {
-    cleanupSnapshot(['req-update']);
+    cleanupAllSnapshots();
     emitLiveMetrics(makeEvent({
         requestId: 'req-update',
         type: 'requestStarted',
@@ -77,11 +75,11 @@ test('snapshot is updated to latest event for the same requestId', () => {
     assert.equal(found.estimatedOutputTokens, 50);
     assert.equal(found.tokensPerSecond, 25.5);
 
-    cleanupSnapshot(['req-update']);
+    cleanupAllSnapshots();
 });
 
 test('multiple concurrent requests have independent snapshots', () => {
-    cleanupSnapshot(['req-a', 'req-b']);
+    cleanupAllSnapshots();
     emitLiveMetrics(makeEvent({ requestId: 'req-a', type: 'requestStarted' }));
     emitLiveMetrics(makeEvent({ requestId: 'req-b', type: 'streamingUpdate', estimatedOutputTokens: 100 }));
 
@@ -101,11 +99,11 @@ test('multiple concurrent requests have independent snapshots', () => {
     assert.ok(!afterCleanup.some(e => e.requestId === 'req-a'), 'req-a should be removed');
     assert.ok(afterCleanup.some(e => e.requestId === 'req-b'), 'req-b should still exist');
 
-    cleanupSnapshot(['req-b']);
+    cleanupAllSnapshots();
 });
 
 test('listeners still receive events alongside snapshot updates', () => {
-    cleanupSnapshot(['req-listener']);
+    cleanupAllSnapshots();
     const received: LiveStreamMetricEvent[] = [];
     const disposable = onLiveMetrics(event => {
         if (event.requestId === 'req-listener') {
@@ -121,28 +119,236 @@ test('listeners still receive events alongside snapshot updates', () => {
         assert.equal(received[0].type, 'requestStarted');
         assert.equal(received[1].type, 'streamingUpdate');
 
-        // snapshot 也有最新状态
         const snapshot = getActiveMetricsSnapshot();
         const found = snapshot.find(e => e.requestId === 'req-listener');
         assert.ok(found);
         assert.equal(found.type, 'streamingUpdate');
     } finally {
         disposable.dispose();
-        cleanupSnapshot(['req-listener']);
+        cleanupAllSnapshots();
     }
 });
 
 test('getActiveMetricsSnapshot returns empty array when no active requests', () => {
-    // 清理本测试文件中所有可能残留的 requestId
-    cleanupSnapshot([
-        'req-1',
-        'req-no-listener',
-        'req-end',
-        'req-update',
-        'req-a',
-        'req-b',
-        'req-listener'
-    ]);
-
+    cleanupAllSnapshots();
     assert.deepEqual(getActiveMetricsSnapshot(), []);
+});
+
+test('dispose stops listener from receiving further events', () => {
+    cleanupAllSnapshots();
+    const received: LiveStreamMetricEvent[] = [];
+    const disposable = onLiveMetrics(event => received.push(event));
+
+    emitLiveMetrics(makeEvent({ requestId: 'req-dispose', type: 'requestStarted' }));
+    assert.equal(received.length, 1, 'should receive before dispose');
+
+    disposable.dispose();
+
+    emitLiveMetrics(makeEvent({ requestId: 'req-dispose', type: 'streamingUpdate' }));
+    assert.equal(received.length, 1, 'should not receive after dispose');
+
+    // dispose 后 snapshot 仍会更新
+    const snapshot = getActiveMetricsSnapshot();
+    const found = snapshot.find(e => e.requestId === 'req-dispose');
+    assert.ok(found);
+    assert.equal(found.type, 'streamingUpdate');
+
+    cleanupAllSnapshots();
+});
+
+test('multiple listeners all receive the same event', () => {
+    cleanupAllSnapshots();
+    const received1: LiveStreamMetricEvent[] = [];
+    const received2: LiveStreamMetricEvent[] = [];
+    const d1 = onLiveMetrics(event => received1.push(event));
+    const d2 = onLiveMetrics(event => received2.push(event));
+
+    try {
+        emitLiveMetrics(makeEvent({ requestId: 'req-multi', type: 'requestStarted' }));
+
+        assert.equal(received1.length, 1);
+        assert.equal(received2.length, 1);
+        assert.equal(received1[0].requestId, 'req-multi');
+        assert.equal(received2[0].requestId, 'req-multi');
+    } finally {
+        d1.dispose();
+        d2.dispose();
+        cleanupAllSnapshots();
+    }
+});
+
+test('listener exception does not break other listeners', () => {
+    cleanupAllSnapshots();
+
+    // 临时 stub console.warn，避免测试输出噪声
+    const originalWarn = console.warn;
+    let warned = false;
+    console.warn = (...args: unknown[]) => {
+        warned = String(args[0]).includes('[LiveMetrics] listener failed');
+    };
+
+    const received: LiveStreamMetricEvent[] = [];
+    const d1 = onLiveMetrics(() => {
+        throw new Error('boom');
+    });
+    const d2 = onLiveMetrics(event => received.push(event));
+
+    try {
+        emitLiveMetrics(makeEvent({ requestId: 'req-error', type: 'requestStarted' }));
+
+        assert.equal(warned, true, 'listener failure should be logged');
+        assert.equal(received.length, 1);
+        assert.equal(received[0].requestId, 'req-error');
+
+        const snapshot = getActiveMetricsSnapshot();
+        assert.ok(snapshot.some(e => e.requestId === 'req-error'));
+    } finally {
+        console.warn = originalWarn;
+        d1.dispose();
+        d2.dispose();
+        cleanupAllSnapshots();
+    }
+});
+
+test('streamEnd for non-existent requestId is a no-op', () => {
+    cleanupAllSnapshots();
+    emitLiveMetrics(makeEvent({ requestId: 'req-exist', type: 'streamingUpdate' }));
+
+    // 对另一个 requestId 发送 streamEnd
+    emitLiveMetrics(makeEvent({ requestId: 'req-ghost', type: 'streamEnd' }));
+
+    // req-exist 应不受影响
+    const snapshot = getActiveMetricsSnapshot();
+    assert.equal(snapshot.length, 1);
+    assert.equal(snapshot[0].requestId, 'req-exist');
+
+    cleanupAllSnapshots();
+});
+
+test('full lifecycle: requestStarted -> firstChunk -> streamingUpdate -> streamEnd', () => {
+    cleanupAllSnapshots();
+    const events: LiveStreamMetricEvent[] = [];
+    const disposable = onLiveMetrics(event => events.push(event));
+
+    try {
+        // requestStarted 阶段
+        emitLiveMetrics(makeEvent({
+            requestId: 'req-lifecycle',
+            type: 'requestStarted',
+            requestStartTime: 1000
+        }));
+        let snapshot = getActiveMetricsSnapshot();
+        assert.equal(snapshot.find(e => e.requestId === 'req-lifecycle')!.type, 'requestStarted');
+
+        // firstChunk 阶段
+        emitLiveMetrics(makeEvent({
+            requestId: 'req-lifecycle',
+            type: 'firstChunk',
+            streamStartTime: 1200,
+            firstChunkLatencyMs: 200
+        }));
+        snapshot = getActiveMetricsSnapshot();
+        const fc = snapshot.find(e => e.requestId === 'req-lifecycle')!;
+        assert.equal(fc.type, 'firstChunk');
+        assert.equal(fc.firstChunkLatencyMs, 200);
+
+        // streamingUpdate 阶段
+        emitLiveMetrics(makeEvent({
+            requestId: 'req-lifecycle',
+            type: 'streamingUpdate',
+            estimatedOutputTokens: 42,
+            lastOutputTokenDelta: 10,
+            tokensPerSecond: 21.0
+        }));
+        snapshot = getActiveMetricsSnapshot();
+        const su = snapshot.find(e => e.requestId === 'req-lifecycle')!;
+        assert.equal(su.type, 'streamingUpdate');
+        assert.equal(su.estimatedOutputTokens, 42);
+        assert.equal(su.lastOutputTokenDelta, 10);
+        assert.equal(su.tokensPerSecond, 21.0);
+
+        // streamEnd 阶段
+        emitLiveMetrics(makeEvent({
+            requestId: 'req-lifecycle',
+            type: 'streamEnd'
+        }));
+        snapshot = getActiveMetricsSnapshot();
+        assert.ok(!snapshot.some(e => e.requestId === 'req-lifecycle'), 'should be removed after streamEnd');
+
+        // listener 应收到全部 4 个事件
+        assert.equal(events.length, 4);
+        assert.equal(events[0].type, 'requestStarted');
+        assert.equal(events[1].type, 'firstChunk');
+        assert.equal(events[2].type, 'streamingUpdate');
+        assert.equal(events[3].type, 'streamEnd');
+    } finally {
+        disposable.dispose();
+        cleanupAllSnapshots();
+    }
+});
+
+test('snapshot preserves all event fields', () => {
+    cleanupAllSnapshots();
+    const fullEvent = makeEvent({
+        requestId: 'req-fields',
+        type: 'streamingUpdate',
+        requestStartTime: 5000,
+        providerName: 'Anthropic',
+        modelName: 'claude-sonnet-4-20250514',
+        streamStartTime: 5300,
+        firstChunkLatencyMs: 300,
+        estimatedOutputTokens: 150,
+        lastOutputTokenDelta: 25,
+        lastFlushSeq: 7,
+        tokensPerSecond: 33.3
+    });
+
+    emitLiveMetrics(fullEvent);
+
+    const snapshot = getActiveMetricsSnapshot();
+    const found = snapshot.find(e => e.requestId === 'req-fields')!;
+
+    assert.equal(found.type, 'streamingUpdate');
+    assert.equal(found.requestId, 'req-fields');
+    assert.equal(found.requestStartTime, 5000);
+    assert.equal(found.providerName, 'Anthropic');
+    assert.equal(found.modelName, 'claude-sonnet-4-20250514');
+    assert.equal(found.streamStartTime, 5300);
+    assert.equal(found.firstChunkLatencyMs, 300);
+    assert.equal(found.estimatedOutputTokens, 150);
+    assert.equal(found.lastOutputTokenDelta, 25);
+    assert.equal(found.lastFlushSeq, 7);
+    assert.equal(found.tokensPerSecond, 33.3);
+
+    cleanupAllSnapshots();
+});
+
+test('retry (new requestStarted for same requestId) resets snapshot', () => {
+    cleanupAllSnapshots();
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-retry',
+        type: 'requestStarted',
+        requestStartTime: 1000
+    }));
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-retry',
+        type: 'streamingUpdate',
+        requestStartTime: 1000,
+        estimatedOutputTokens: 100
+    }));
+
+    // 重试：新的 requestStarted 带不同 requestStartTime
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-retry',
+        type: 'requestStarted',
+        requestStartTime: 3000
+    }));
+
+    const snapshot = getActiveMetricsSnapshot();
+    const found = snapshot.find(e => e.requestId === 'req-retry')!;
+    assert.equal(found.type, 'requestStarted', 'should be reset to requestStarted');
+    assert.equal(found.requestStartTime, 3000, 'should have new attempt start time');
+    assert.equal(found.estimatedOutputTokens, undefined, 'old streamingUpdate fields should be gone');
+
+    cleanupAllSnapshots();
 });

--- a/src/handlers/liveMetrics.test.ts
+++ b/src/handlers/liveMetrics.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { emitLiveMetrics, getActiveMetricsSnapshot, onLiveMetrics, type LiveStreamMetricEvent } from './liveMetrics';
+
+function makeEvent(overrides: Partial<LiveStreamMetricEvent> = {}): LiveStreamMetricEvent {
+    return {
+        type: 'streamingUpdate',
+        requestId: 'req-1',
+        requestStartTime: 1000,
+        providerName: 'TestProvider',
+        modelName: 'test-model',
+        ...overrides
+    };
+}
+
+// 每个测试前清空快照（通过 streamEnd 清理所有已知 requestId）
+// 由于 activeMetrics 是模块私有的，通过 emit streamEnd 清理
+function cleanupSnapshot(requestIds: string[]): void {
+    for (const id of requestIds) {
+        emitLiveMetrics(makeEvent({ type: 'streamEnd', requestId: id }));
+    }
+}
+
+test('emitLiveMetrics updates snapshot even when no listeners exist', () => {
+    cleanupSnapshot(['req-no-listener']);
+    const event = makeEvent({ requestId: 'req-no-listener', type: 'requestStarted' });
+
+    // 无 listener 时 emit
+    emitLiveMetrics(event);
+
+    const snapshot = getActiveMetricsSnapshot();
+    const found = snapshot.find(e => e.requestId === 'req-no-listener');
+    assert.ok(found, 'snapshot should contain the event even without listeners');
+    assert.equal(found.type, 'requestStarted');
+
+    cleanupSnapshot(['req-no-listener']);
+});
+
+test('streamEnd removes requestId from snapshot', () => {
+    cleanupSnapshot(['req-end']);
+    emitLiveMetrics(makeEvent({ requestId: 'req-end', type: 'streamingUpdate' }));
+
+    let snapshot = getActiveMetricsSnapshot();
+    assert.ok(snapshot.some(e => e.requestId === 'req-end'), 'should exist before streamEnd');
+
+    emitLiveMetrics(makeEvent({ requestId: 'req-end', type: 'streamEnd' }));
+
+    snapshot = getActiveMetricsSnapshot();
+    assert.ok(!snapshot.some(e => e.requestId === 'req-end'), 'should be removed after streamEnd');
+});
+
+test('snapshot is updated to latest event for the same requestId', () => {
+    cleanupSnapshot(['req-update']);
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-update',
+        type: 'requestStarted',
+        requestStartTime: 1000
+    }));
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-update',
+        type: 'firstChunk',
+        streamStartTime: 1200,
+        firstChunkLatencyMs: 200
+    }));
+    emitLiveMetrics(makeEvent({
+        requestId: 'req-update',
+        type: 'streamingUpdate',
+        estimatedOutputTokens: 50,
+        tokensPerSecond: 25.5
+    }));
+
+    const snapshot = getActiveMetricsSnapshot();
+    const found = snapshot.find(e => e.requestId === 'req-update');
+    assert.ok(found, 'should exist');
+    assert.equal(found.type, 'streamingUpdate', 'should be the latest event type');
+    assert.equal(found.estimatedOutputTokens, 50);
+    assert.equal(found.tokensPerSecond, 25.5);
+
+    cleanupSnapshot(['req-update']);
+});
+
+test('multiple concurrent requests have independent snapshots', () => {
+    cleanupSnapshot(['req-a', 'req-b']);
+    emitLiveMetrics(makeEvent({ requestId: 'req-a', type: 'requestStarted' }));
+    emitLiveMetrics(makeEvent({ requestId: 'req-b', type: 'streamingUpdate', estimatedOutputTokens: 100 }));
+
+    const snapshot = getActiveMetricsSnapshot();
+    const a = snapshot.find(e => e.requestId === 'req-a');
+    const b = snapshot.find(e => e.requestId === 'req-b');
+
+    assert.ok(a, 'req-a should exist');
+    assert.ok(b, 'req-b should exist');
+    assert.equal(a.type, 'requestStarted');
+    assert.equal(b.type, 'streamingUpdate');
+    assert.equal(b.estimatedOutputTokens, 100);
+
+    // 清理 req-a 不影响 req-b
+    emitLiveMetrics(makeEvent({ requestId: 'req-a', type: 'streamEnd' }));
+    const afterCleanup = getActiveMetricsSnapshot();
+    assert.ok(!afterCleanup.some(e => e.requestId === 'req-a'), 'req-a should be removed');
+    assert.ok(afterCleanup.some(e => e.requestId === 'req-b'), 'req-b should still exist');
+
+    cleanupSnapshot(['req-b']);
+});
+
+test('listeners still receive events alongside snapshot updates', () => {
+    cleanupSnapshot(['req-listener']);
+    const received: LiveStreamMetricEvent[] = [];
+    const disposable = onLiveMetrics(event => {
+        if (event.requestId === 'req-listener') {
+            received.push(event);
+        }
+    });
+
+    try {
+        emitLiveMetrics(makeEvent({ requestId: 'req-listener', type: 'requestStarted' }));
+        emitLiveMetrics(makeEvent({ requestId: 'req-listener', type: 'streamingUpdate' }));
+
+        assert.equal(received.length, 2, 'listener should receive both events');
+        assert.equal(received[0].type, 'requestStarted');
+        assert.equal(received[1].type, 'streamingUpdate');
+
+        // snapshot 也有最新状态
+        const snapshot = getActiveMetricsSnapshot();
+        const found = snapshot.find(e => e.requestId === 'req-listener');
+        assert.ok(found);
+        assert.equal(found.type, 'streamingUpdate');
+    } finally {
+        disposable.dispose();
+        cleanupSnapshot(['req-listener']);
+    }
+});
+
+test('getActiveMetricsSnapshot returns empty array when no active requests', () => {
+    // 清理本测试文件中所有可能残留的 requestId
+    cleanupSnapshot([
+        'req-1',
+        'req-no-listener',
+        'req-end',
+        'req-update',
+        'req-a',
+        'req-b',
+        'req-listener'
+    ]);
+
+    assert.deepEqual(getActiveMetricsSnapshot(), []);
+});

--- a/src/handlers/liveMetrics.ts
+++ b/src/handlers/liveMetrics.ts
@@ -4,8 +4,6 @@
  *  不依赖 status 层，仅作为轻量 typed event bus。
  *---------------------------------------------------------------------------------------------*/
 
-import { Logger } from '../utils/logger';
-
 export interface LiveStreamMetricEvent {
     type: 'requestStarted' | 'firstChunk' | 'streamingUpdate' | 'streamEnd';
     requestId: string;
@@ -40,6 +38,12 @@ type LiveMetricsListener = (event: LiveStreamMetricEvent) => void;
 
 const listeners = new Set<LiveMetricsListener>();
 
+/**
+ * 活跃请求的最新事件快照（requestId → 最新事件）。
+ * 面板中途打开时用于补发当前流式状态，避免因订阅晚于事件发送而丢失数据。
+ */
+const activeMetrics = new Map<string, LiveStreamMetricEvent>();
+
 export function onLiveMetrics(listener: LiveMetricsListener): { dispose(): void } {
     listeners.add(listener);
     return {
@@ -50,6 +54,13 @@ export function onLiveMetrics(listener: LiveMetricsListener): { dispose(): void 
 }
 
 export function emitLiveMetrics(event: LiveStreamMetricEvent): void {
+    // 快照更新 — 无论是否有 listener 都必须执行，否则面板未打开时无法缓存
+    if (event.type === 'streamEnd') {
+        activeMetrics.delete(event.requestId);
+    } else {
+        activeMetrics.set(event.requestId, event);
+    }
+
     if (listeners.size === 0) {
         return;
     }
@@ -58,7 +69,15 @@ export function emitLiveMetrics(event: LiveStreamMetricEvent): void {
         try {
             listener(event);
         } catch (error) {
-            Logger.warn('[LiveMetrics] listener failed:', error);
+            console.warn('[LiveMetrics] listener failed:', error);
         }
     }
+}
+
+/**
+ * 获取当前活跃请求的最新事件快照。
+ * 供面板打开 / 日期切换时补发当前流式状态。
+ */
+export function getActiveMetricsSnapshot(): LiveStreamMetricEvent[] {
+    return Array.from(activeMetrics.values());
 }

--- a/src/ui/usagesView/index.ts
+++ b/src/ui/usagesView/index.ts
@@ -13,7 +13,7 @@ import { UpdateDateDetailsMessage, UpdateDateListMessage, UpdateLiveMetricsMessa
 import type { WebViewMessage } from './types';
 import { getTodayDateString } from './utils';
 import { MultiDayView } from '../multiDayView';
-import { onLiveMetrics, type LiveStreamMetricEvent } from '../../handlers/liveMetrics';
+import { onLiveMetrics, getActiveMetricsSnapshot, type LiveStreamMetricEvent } from '../../handlers/liveMetrics';
 
 /**
  * Token 用量 WebView 视图
@@ -74,14 +74,10 @@ export class TokenUsagesView {
         // 监听实时流式指标事件（retainContextWhenHidden 下隐藏面板仍可接收消息）
         // 仅在查看今天时转发给 WebView，非今天直接跳过 postMessage（IPC 序列化开销）
         this.liveMetricsDisposable = onLiveMetrics((event: LiveStreamMetricEvent) => {
-            if (!this.panel) {
+            if (!this.shouldForwardLiveMetrics()) {
                 return;
             }
-            const today = getTodayDateString();
-            if (this.currentSelectedDate !== today) {
-                return;
-            }
-            this.handleLiveMetricEvent(event);
+            this.postLiveMetricEvent(event);
         });
 
         // 监听关闭
@@ -204,7 +200,7 @@ export class TokenUsagesView {
             this.currentSelectedDate = displayDate;
 
             // 发送日期列表（直接发送原始数据，全量）
-            this.panel.webview.postMessage({
+            await this.panel.webview.postMessage({
                 command: 'updateDateList',
                 dateList: dateSummaries,
                 selectedDate: displayDate,
@@ -212,7 +208,7 @@ export class TokenUsagesView {
             } as UpdateDateListMessage);
 
             // 发送日期详情（直接发送原始数据）
-            this.panel.webview.postMessage({
+            await this.panel.webview.postMessage({
                 command: 'updateDateDetails',
                 date: displayDate,
                 isToday: displayDate === today,
@@ -234,6 +230,7 @@ export class TokenUsagesView {
         switch (message.command) {
             case 'getInitialData':
                 await this.sendInitialData();
+                this.pushActiveLiveMetricsSnapshot();
                 break;
 
             case 'refresh':
@@ -242,6 +239,7 @@ export class TokenUsagesView {
 
             case 'selectDate':
                 await this.updateDateDetails(message.date);
+                this.pushActiveLiveMetricsSnapshot();
                 break;
 
             case 'openStorageDir':
@@ -255,11 +253,16 @@ export class TokenUsagesView {
     }
 
     /**
-     * 处理实时流式指标事件，发送给 WebView 更新显示
-     * 不在 Extension 层过滤日期——WebView 端已有 isViewingToday() 控制是否渲染，
-     * 这样用户从历史日期切回今天时不会丢失正在进行的 live events。
+     * 判断是否应转发实时流式指标给 WebView（面板已打开且正在查看今天）
      */
-    private handleLiveMetricEvent(event: LiveStreamMetricEvent): void {
+    private shouldForwardLiveMetrics(): boolean {
+        return !!this.panel && this.currentSelectedDate === getTodayDateString();
+    }
+
+    /**
+     * 将单个实时流式指标事件发送给 WebView
+     */
+    private postLiveMetricEvent(event: LiveStreamMetricEvent): void {
         const panel = this.panel;
         if (!panel) {
             return;
@@ -283,6 +286,19 @@ export class TokenUsagesView {
                 );
         } catch (err) {
             StatusLogger.warn('[TokenUsagesView] failed to post live metric message:', err);
+        }
+    }
+
+    /**
+     * 推送当前活跃请求的最新事件快照给 WebView。
+     * 用于面板打开（getInitialData）和日期切换（selectDate）后补发实时状态。
+     */
+    private pushActiveLiveMetricsSnapshot(): void {
+        if (!this.shouldForwardLiveMetrics()) {
+            return;
+        }
+        for (const event of getActiveMetricsSnapshot()) {
+            this.postLiveMetricEvent(event);
         }
     }
 
@@ -324,7 +340,7 @@ export class TokenUsagesView {
 
             // 发送消息给 WebView，让它更新详情区域
             if (this.panel) {
-                this.panel.webview.postMessage({
+                await this.panel.webview.postMessage({
                     command: 'updateDateDetails',
                     date,
                     isToday: date === today,

--- a/src/ui/usagesView/types.ts
+++ b/src/ui/usagesView/types.ts
@@ -12,7 +12,7 @@ import type {
     HourlyStats
 } from '../../usages/fileLogger/types';
 import type { ExtendedTokenRequestLog } from '../../usages/fileLogger/usageParser';
-import type { LiveStreamMetricEvent } from '../../metrics/liveMetrics';
+import type { LiveStreamMetricEvent } from '../../handlers/liveMetrics';
 
 // ============= UI 层数据类型 =============
 


### PR DESCRIPTION
## 概述

修复 Token Usage 面板在流式请求已开始后才打开时，输出耗时、输出 token 数和输出速度显示为 `-` 的问题。

## 主要改动

- 在 `liveMetrics` 中新增活跃请求快照，未打开面板时也会记录最新实时指标
- 面板初始化和切换日期后，自动补发当前仍在进行中的实时指标
- 仅在查看今天时转发实时指标，减少无效 WebView 消息
- 将关键 `postMessage` 改为等待完成，降低初始化时序问题
- 修正 `LiveStreamMetricEvent` 类型导入路径
- 新增单元测试覆盖快照更新、清理、并发请求、监听器异常隔离等场景

## 测试

- 新增 `src/handlers/liveMetrics.test.ts`
- 覆盖实时指标快照的生命周期和边界行为
