### PR TITLE
fix(streamReporter): swap endThinkingChain and flushText order to fix thinking fold rendering

### DIFF
--- a/src/handlers/streamReporter.ts
+++ b/src/handlers/streamReporter.ts
@@ -79,7 +79,7 @@ export interface StreamReporterOptions {
  *
  * 关键实现约定：
  * - 文本/思考缓冲阈值均为 20 字符
- * - accumulateToolCall 首次创建某 index 的 buffer 时立即 flushThinking + flushText + endThinkingChain
+ * - accumulateToolCall 首次创建某 index 的 buffer 时立即 flushThinking + endThinkingChain + flushText
  * - 工具调用完成时只 flushThinking + flushSignature + thoughtSignature，不主动 endThinkingChain
  * - flushSignature 输出"空文本 + signature"的 ThinkingPart，不消费 thinking buffer 内容
  * - flushAll 中 signature 紧跟 thinking 输出，在 endThinkingChain 之前
@@ -232,8 +232,8 @@ export class StreamReporter {
      */
     reportToolResult(callId: string, content: string | vscode.LanguageModelTextPart[]): void {
         this.flushThinking('Before reporting tool result');
-        this.flushText('Before reporting tool result');
         this.endThinkingChain();
+        this.flushText('Before reporting tool result');
 
         const parts = typeof content === 'string' ? [new vscode.LanguageModelTextPart(content)] : content;
         this.progress.report(new vscode.LanguageModelToolResultPart(callId, parts));
@@ -307,7 +307,7 @@ export class StreamReporter {
      * 当检测到工具调用完成时，立即报告
      *
      * 关键实现约定：
-     * - 首次为某 index 创建工具调用 buffer 时：flushThinking + flushText + endThinkingChain
+ * - 首次为某 index 创建工具调用 buffer 时：flushThinking + endThinkingChain + flushText
      * - 工具完成时：flushText + flushThinking + flushSignature + thoughtSignature
      *   （不调用 endThinkingChain，思维链的结束留给后续 reportText / flushAll 处理）
      */
@@ -319,11 +319,13 @@ export class StreamReporter {
     ): void {
         const { isNew, completed } = this.toolCallAccumulator.accumulate(index, id, name, argsFragment);
 
-        // 首次为该 index 创建工具调用 buffer 时，flush 剩余 thinking 和文本，并结束思维链
+        // 首次为该 index 创建工具调用 buffer 时，flush 剩余 thinking，结束思维链，再输出文本
+        // 必须在 endThinkingChain 之后再 flushText，否则 TextPart 会在 thinking chain 仍 active 时被报告，
+        // 导致 VS Code 将文本归入 thinking fold 内部（表现为内容被折叠、下方出现空框）
         if (isNew) {
             this.flushThinking('Before tool call start');
-            this.flushText('Before tool call start');
             this.endThinkingChain();
+            this.flushText('Before tool call start');
         }
 
         // tool argument delta 是 provider 实际回传的一部分，计入 token 估算


### PR DESCRIPTION
## 问题描述

在使用 GCMP 插件时，模型的文本响应内容有时会被错误地渲染到 **thinking 折叠区域内部**，导致：
- 用户看到的文本（如工具执行结果）被折叠在 thinking fold 里
- 折叠区域下方出现一个空框

这个问题**间歇性触发**，取决于模型输出的 thinking 长度和 tool call 时序。

## 根因分析

问题出在 `streamReporter.ts` 的两个方法中：

### `accumulateToolCall` 方法

```typescript
// 修复前
if (isNew) {
    this.flushThinking('Before tool call start');
    this.flushText('Before tool call start');      // TextPart 在 thinking chain active 时被报告
    this.endThinkingChain();                        // thinking chain 才在这里关闭
}
```

### `reportToolResult` 方法

```typescript
// 修复前
reportToolResult(callId, content) {
    this.flushThinking('Before reporting tool result');
    this.flushText('Before reporting tool result');  // 同样的顺序问题
    this.endThinkingChain();
}
```

`flushText()` 在 `endThinkingChain()` **之前**被调用。当 `flushText()` 报告 `LanguageModelTextPart` 时，thinking chain 仍然 active（`currentId` 非 null），VS Code Chat UI 会将这个 TextPart **归入当前活跃的 thinking fold 内部**。

### 间歇性触发的原因

GCMP 的 `ThinkingBuffer` 和 `TextBuffer` 有 **20 字符的 flush 阈值**。当 thinking 内容很短（< 20 字符）且 tool call 紧跟到达时，buffer 未达阈值自动 flush，tool call 强制触发 flush 时就会暴露顺序问题。thinking 足够长时已提前自动 flush，不触发 bug。

## 修复方案

将 `endThinkingChain()` 移到 `flushText()` **之前**：

```typescript
// 修复后
if (isNew) {
    this.flushThinking('Before tool call start');
    this.endThinkingChain();                        // 先关闭 thinking chain
    this.flushText('Before tool call start');        // 再输出文本
}
```

`reportToolResult` 同理。

> 注：`flushAll` 和 `reportText` 方法中的顺序已经是正确的，问题仅存在于上述两处。

## 本地验证

修复后在本地使用 DeepSeek-V4-Flash 测试，thinking 短 + tool call 场景下的文本不再被归入 thinking fold。
