### PR TITLE
feat(providers/dashscope): 添加 kimi-k2.7-code 与 glm-5.2，移除已下线的 glm-5.2 CodingPlan

### DIFF
--- a/src/providers/config/dashscope.json
+++ b/src/providers/config/dashscope.json
@@ -244,6 +244,25 @@
             "capabilities": { "toolCalling": true, "imageInput": false }
         },
         {
+            "id": "kimi-k2.7-code-token-plan",
+            "name": "Kimi-K2.7-Code (TokenPlan)",
+            "tooltip": "Dashscope Token Plan 团队版专属接入点（Anthropic API 兼容协议）。",
+            "provider": "dashscope-token",
+            "sdkMode": "anthropic",
+            "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+            "model": "kimi-k2.7-code",
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 262144,
+            "thinking": [
+                "enabled",
+                "disabled"
+            ],
+            "capabilities": {
+                "toolCalling": true,
+                "imageInput": true
+            }
+        },
+        {
             "id": "kimi-k2.6-token-plan",
             "name": "Kimi-K2.6 (TokenPlan)",
             "tooltip": "Dashscope Token Plan 团队版专属接入点（Anthropic API 兼容协议）。",
@@ -423,6 +442,29 @@
             "maxInputTokens": 1000000,
             "maxOutputTokens": 384000,
             "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "glm-5.2",
+            "name": "GLM-5.2",
+            "tooltip": "智谱 GLM-5.2 旗舰模型，支持 100 万上下文窗口，推理能力强。",
+            "sdkMode": "anthropic",
+            "baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
+            "reasoningEffort": ["high", "max", "none"],
+            "contextSize": [1000000, 600000, 400000, 200000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 128000,
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "kimi-k2.7-code",
+            "name": "Kimi-K2.7-Code",
+            "tooltip": "Moonshot AI 代码推理模型，支持 262K 上下文与输出窗口，擅长代码生成与理解。",
+            "sdkMode": "anthropic",
+            "baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 262144,
+            "thinking": ["enabled", "disabled"],
+            "capabilities": { "toolCalling": true, "imageInput": true }
         }
     ]
 }


### PR DESCRIPTION
## 变更说明

Fixes #255

### 新增模型

| 模型 ID | 名称 | Token Plan | 官方 API |
|---|---|---|---|
| `kimi-k2.7-code` | Kimi-K2.7-Code | ✅ (新增) | ✅ (新增) |
| `glm-5.2` | GLM-5.2 | ✅ (已存在) | ✅ (新增) |

### 模型参数参考

**kimi-k2.7-code**（[models.dev](https://models.dev/models/moonshotai/kimi-k2.7-code/)）：
- 上下文窗口：262,144
- 最大输出：262,144
- 能力：reasoning, toolCalling, imageInput（TEXT IMAGE VIDEO）

**glm-5.2**（[models.dev](https://models.dev/models/zhipuai/glm-5.2/)）：
- 上下文窗口：1,000,000
- 最大输出：131,072
- 能力：reasoning, toolCalling