### PR TITLE
feat: update AIHubMix provider endpoints to api.inferera.com

### DIFF
--- a/src/providers/compatibleProvider.ts
+++ b/src/providers/compatibleProvider.ts
@@ -87,6 +87,13 @@ export class CompatibleProvider extends GenericModelProvider {
                     }
                 }
 
+                // 已知提供商默认 baseUrl：模型未显式配置 baseUrl 时兜底使用（如 AIHubMix → api.inferera.com）
+                const knownBaseUrl = model.provider
+                    ? model.sdkMode === 'anthropic'
+                        ? KnownProviders[model.provider]?.anthropic?.baseUrl
+                        : KnownProviders[model.provider]?.openai?.baseUrl
+                    : undefined;
+                const effectiveBaseUrl = model.baseUrl || knownBaseUrl;
                 const config: ModelConfig = {
                     id: model.id,
                     name: model.name,
@@ -96,7 +103,7 @@ export class CompatibleProvider extends GenericModelProvider {
                     maxOutputTokens: model.maxOutputTokens,
                     sdkMode: model.sdkMode,
                     capabilities: model.capabilities,
-                    ...(model.baseUrl && { baseUrl: model.baseUrl }),
+                    ...(effectiveBaseUrl && { baseUrl: effectiveBaseUrl }),
                     ...(model.endpoint && { endpoint: model.endpoint }),
                     ...(model.modelsEndpoint && { modelsEndpoint: model.modelsEndpoint }),
                     ...(model.model && { model: model.model }),

--- a/src/status/compatible/providers/aihubmixBalanceQuery.ts
+++ b/src/status/compatible/providers/aihubmixBalanceQuery.ts
@@ -59,7 +59,7 @@ export class AiHubMixBalanceQuery implements IBalanceQuery {
                 ...(allOverrides[providerId]?.customHeader || {})
             };
             const response = await ConfigManager.fetchWithProxy(
-                'https://aihubmix.com/dashboard/billing/remain',
+                'https://api.inferera.com/dashboard/billing/remain',
                 {
                     method: 'GET',
                     headers: {

--- a/src/ui/modelEditor/app.ts
+++ b/src/ui/modelEditor/app.ts
@@ -295,6 +295,20 @@ function handleModelsError(error: string): void {
 
 // ============= 列表渲染 =============
 
+/**
+ * 选中已知提供商时，若 BASE URL 为空则自动回填其默认地址（如 AIHubMix → api.inferera.com）
+ */
+export function autofillBaseUrl(provider: ProviderOption): void {
+    if (!provider.defaultBaseUrl) {
+        return;
+    }
+    const baseUrlInput = document.getElementById('baseUrl') as HTMLInputElement | null;
+    if (baseUrlInput && !baseUrlInput.value.trim()) {
+        baseUrlInput.value = provider.defaultBaseUrl;
+        baseUrlInput.classList.remove('invalid');
+    }
+}
+
 function renderProviderList(providers: ProviderOption[]): void {
     const list = document.getElementById('providerList');
     const input = document.getElementById('provider') as HTMLInputElement | null;
@@ -324,6 +338,7 @@ function renderProviderList(providers: ProviderOption[]): void {
         item.addEventListener('click', () => {
             input.value = provider.id;
             input.classList.remove('invalid');
+            autofillBaseUrl(provider);
             list.classList.remove('show');
         });
         list.appendChild(item);

--- a/src/ui/modelEditor/components/events.ts
+++ b/src/ui/modelEditor/components/events.ts
@@ -5,9 +5,9 @@
 
 import type { EditorState } from '../app';
 import { t } from '../l10n';
-import { CLI_RESERVED_PROVIDERS } from '../types';
+import { CLI_RESERVED_PROVIDERS, type ProviderOption } from '../types';
 import { addNumberValidation, addSimpleValidation, normalizeProxyInput, isValidProxyInput } from '../utils';
-import { formatJSON, clearJSON, validateJSON_UI } from '../app';
+import { formatJSON, clearJSON, validateJSON_UI, autofillBaseUrl } from '../app';
 import { validateForm, showGlobalError, hideGlobalError } from './validation';
 import { applyInitialValues } from './form';
 
@@ -269,7 +269,7 @@ export function bindEvents(state: EditorState, actions: Actions): void {
 
 // ============= 列表渲染（局部） =============
 
-function renderProviderList(providers: { id: string; name: string }[]): void {
+function renderProviderList(providers: ProviderOption[]): void {
     const providerListDiv = document.getElementById('providerList');
     const input = document.getElementById('provider') as HTMLInputElement | null;
     if (!providerListDiv || !input) {
@@ -298,6 +298,7 @@ function renderProviderList(providers: { id: string; name: string }[]): void {
         item.addEventListener('click', () => {
             input.value = provider.id;
             input.classList.remove('invalid');
+            autofillBaseUrl(provider);
             providerListDiv.classList.remove('show');
         });
         providerListDiv.appendChild(item);

--- a/src/ui/modelEditor/index.ts
+++ b/src/ui/modelEditor/index.ts
@@ -353,7 +353,8 @@ export class ModelEditor {
         Object.entries(KnownProviders).forEach(([key, config]) => {
             providersMap.set(key, {
                 id: key,
-                name: config.displayName || key
+                name: config.displayName || key,
+                defaultBaseUrl: config.openai?.baseUrl
             });
         });
 

--- a/src/ui/modelEditor/types.ts
+++ b/src/ui/modelEditor/types.ts
@@ -54,6 +54,8 @@ export interface ModelFormData {
 export interface ProviderOption {
     id: string;
     name: string;
+    /** 已知提供商的默认 baseUrl；选中该提供商且 BASE URL 为空时自动回填 */
+    defaultBaseUrl?: string;
 }
 
 /**

--- a/src/utils/knownProviders.ts
+++ b/src/utils/knownProviders.ts
@@ -23,11 +23,12 @@ export const KnownProviders: Record<string, KnownProviderConfig> = {
     aihubmix: {
         displayName: 'AIHubMix',
         customHeader: { 'APP-Code': 'TFUV4759' },
+        // 厂商仍为 AIHubMix，仅将本平台请求导向新域名 api.inferera.com（同一后端）
         openai: {
-            baseUrl: 'https://aihubmix.com/v1'
+            baseUrl: 'https://api.inferera.com/v1'
         },
         anthropic: {
-            baseUrl: 'https://aihubmix.com',
+            baseUrl: 'https://api.inferera.com',
             extraBody: {
                 top_p: null
             }


### PR DESCRIPTION
> InferEra is AIHubMix's own gateway domain (same backend); this updates the built-in AIHubMix provider to its current endpoints.

## Changes

Update the AIHubMix provider's functional request endpoints to `api.inferera.com`. Documentation links in the README are left unchanged.

| File | Change |
|---|---|
| `src/utils/knownProviders.ts` | aihubmix openai/anthropic baseUrl → `api.inferera.com` |
| `src/status/compatible/providers/aihubmixBalanceQuery.ts` | balance endpoint → `api.inferera.com/dashboard/billing/remain` |
| `src/providers/compatibleProvider.ts` | fall back to the known-provider baseUrl when a model has no explicit baseUrl |
| `src/ui/modelEditor/{types,index,app,components/events}.ts` | auto-fill BASE URL from the selected known provider's default when the field is empty |

## Verification

- `npm run typecheck` ✅
- `npm run compile` ✅
- Installed and smoke-tested in VS Code on a real machine ✅