### PR TITLE
feat(providers): 新增 ClinePass 模型提供商支持

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -210,6 +210,13 @@ LLM service platform under iFLYTEK, accessed via Anthropic SDK mode with dual-pl
 
 - **Preset models**: **DeepSeek-V4-Flash**, **DeepSeek-V4-Pro**, **Qwen3.7-Max**, **Qwen3.7-Plus**, **Qwen3.6-Plus**, **Qwen3.6-Max**, **Qwen3.6-Flash**, **Qwen3-Coder-480B-A35B-Instruct-INT4-Mixed-AR**, **Qwen3-Next-80B-A3B-Instruct**, **GLM-5.2**, **GLM-5.1**, **GLM-5**, **Kimi-K2.7-Code**, **Kimi-K2.6**, **Kimi-K2.5**, **MiniMax-M2.7**, **Llama-4-Maverick-17B-128E-Instruct-FP8**, **Llama-3.3-70B-Instruct**, **Gemma-4-26B-A4B**, **GPT-OSS-120B**
 
+### [**ClinePass**](https://docs.cline.bot/getting-started/clinepass) - ClinePass
+
+Cline's official model subscription service, providing OpenAI-compatible API access via the Cline API with `openai-sse` mode.
+
+- **Preset models**: **GLM-5.2**, **Kimi-K2.7-Code**, **Kimi-K2.6**, **DeepSeek-V4-Pro**, **DeepSeek-V4-Flash**, **MiMo-V2.5**, **MiMo-V2.5-Pro**, **MiniMax-M3**, **Qwen3.7-Max**, **Qwen3.7-Plus**
+- **API Key**: Create and copy your API key from [Cline App → API Keys](https://app.cline.bot/dashboard/account?tab=api-keys), then use the `GCMP: Set ClinePass API Key` command to configure it.
+
 ### OAuth Coding Assistant Providers
 
 > ⚠️ **Risk Warning**: The following providers access APIs by simulating OAuth authentication of official CLI tools. **This may violate third-party terms of service and carries the risk of account bans.** Use only if you are fully informed and voluntarily accept the risks.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ VS Code 在后台使用轻量级模型执行标题生成、提交信息创建、
 
 - **预置模型**：**DeepSeek-V4-Flash**、**DeepSeek-V4-Pro**、**Qwen3.7-Max**、**Qwen3.7-Plus**、**Qwen3.6-Plus**、**Qwen3.6-Max**、**Qwen3.6-Flash**、**Qwen3-Coder-480B-A35B-Instruct-INT4-Mixed-AR**、**Qwen3-Next-80B-A3B-Instruct**、**GLM-5.2**、**GLM-5.1**、**GLM-5**、**Kimi-K2.7-Code**、**Kimi-K2.6**、**Kimi-K2.5**、**MiniMax-M2.7**、**Llama-4-Maverick-17B-128E-Instruct-FP8**、**Llama-3.3-70B-Instruct**、**Gemma-4-26B-A4B**、**GPT-OSS-120B**
 
+### [**ClinePass**](https://docs.cline.bot/getting-started/clinepass) - ClinePass
+
+Cline 官方推出的模型订阅服务，通过 Cline API 提供 OpenAI-compatible 接口，支持 `openai-sse` 模式接入。
+
+- **预置模型**：**GLM-5.2**、**Kimi-K2.7-Code**、**Kimi-K2.6**、**DeepSeek-V4-Pro**、**DeepSeek-V4-Flash**、**MiMo-V2.5**、**MiMo-V2.5-Pro**、**MiniMax-M3**、**Qwen3.7-Max**、**Qwen3.7-Plus**
+- **API Key**：在 [Cline App → API Keys](https://app.cline.bot/dashboard/account?tab=api-keys) 页面创建并复制 API Key，使用 `GCMP: 设置 ClinePass API 密钥` 命令配置。
+
 ### OAuth 认证编程助手提供商
 
 > ⚠️ **风险警告**：以下提供商通过模拟官方 CLI 工具的 OAuth 身份验证方式来实现对应的 API 访问，**可能涉嫌滥用第三方服务条款，存在被官方检测封禁账号的风险**。请仅在确保知情并自愿承担风险的前提下使用。

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "ant-ling",
         "stepfun",
         "LongCat",
+        "clinepass",
         "OpenAI Compatible",
         "Anthropic Compatible",
         "智谱AI",
@@ -83,6 +84,7 @@
         "onLanguageModelProvider:gcmp.grok",
         "onLanguageModelProvider:gcmp.opencode",
         "onLanguageModelProvider:gcmp.hyper",
+        "onLanguageModelProvider:gcmp.clinepass",
         "onLanguageModelProvider:gcmp.compatible",
         "onLanguageModelTool:gcmp_zhipuWebSearch",
         "onLanguageModelTool:gcmp_minimaxWebSearch",
@@ -298,6 +300,11 @@
             {
                 "command": "gcmp.hyper.setApiKey",
                 "title": "%command.hyper.setApiKey%",
+                "category": "GCMP"
+            },
+            {
+                "command": "gcmp.clinepass.setApiKey",
+                "title": "%command.clinepass.setApiKey%",
                 "category": "GCMP"
             },
             {
@@ -901,6 +908,11 @@
                 "vendor": "gcmp.hyper",
                 "displayName": "GCMP · Charm Hyper",
                 "managementCommand": "gcmp.hyper.setApiKey"
+            },
+            {
+                "vendor": "gcmp.clinepass",
+                "displayName": "GCMP · ClinePass",
+                "managementCommand": "gcmp.clinepass.setApiKey"
             },
             {
                 "vendor": "gcmp.codex",

--- a/package.nls.json
+++ b/package.nls.json
@@ -41,6 +41,7 @@
     "command.grok.configWizard": "Grok Build Configuration Wizard (CLI Auth)",
     "command.opencode.setApiKey": "Set OpenCode API Key",
     "command.hyper.setApiKey": "Set Charm Hyper API Key",
+    "command.clinepass.setApiKey": "Set ClinePass API Key",
     "command.compatible.manageModels": "Compatible Provider Settings",
     "command.nesCompletion.toggleManual": "Toggle NES Manual Trigger Mode",
     "command.tokenUsage.showDetails": "View Today's Token Usage Details",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -41,6 +41,7 @@
     "command.grok.configWizard": "Grok Build 配置向导（CLI 认证）",
     "command.opencode.setApiKey": "设置 OpenCode API 密钥",
     "command.hyper.setApiKey": "设置 Charm Hyper API 密钥",
+    "command.clinepass.setApiKey": "设置 ClinePass API 密钥",
     "command.compatible.manageModels": "Compatible Provider 设置",
     "command.nesCompletion.toggleManual": "切换 NES 手动触发模式",
     "command.tokenUsage.showDetails": "查看今日 Token 消耗统计详情",

--- a/src/providers/config/clinepass.json
+++ b/src/providers/config/clinepass.json
@@ -1,0 +1,123 @@
+{
+    "displayName": "ClinePass",
+    "baseUrl": "https://api.cline.bot/api/v1",
+    "apiKeyTemplate": "your_cline_api_key_here",
+    "models": [
+        {
+            "id": "cline-pass/glm-5.2",
+            "name": "GLM-5.2 (ClinePass)",
+            "tooltip": "ClinePass — GLM-5.2。1M 上下文，131K 输出，支持推理与工具调用，纯文本模型，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1000000, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 131072,
+            "reasoningEffort": ["high", "xhigh"],
+            "reasoningFormat": "nested",
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "cline-pass/kimi-k2.7-code",
+            "name": "Kimi-K2.7-Code (ClinePass)",
+            "tooltip": "ClinePass — Kimi K2.7 Code。262K 上下文，262K 输出，支持推理、工具调用与图片/视频输入。",
+            "sdkMode": "openai-sse",
+            "contextSize": [262144, 192000, 128000],
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 262144,
+            "reasoningEffort": ["low", "medium", "high"],
+            "extraBody": { "enabled_thinking": true },
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        },
+        {
+            "id": "cline-pass/kimi-k2.6",
+            "name": "Kimi-K2.6 (ClinePass)",
+            "tooltip": "ClinePass — Kimi K2.6。262K 上下文，262K 输出，支持推理、工具调用与图片/视频输入，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [262144, 192000, 128000],
+            "maxInputTokens": 262144,
+            "maxOutputTokens": 262144,
+            "reasoningEffort": ["low", "medium", "high"],
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        },
+        {
+            "id": "cline-pass/deepseek-v4-pro",
+            "name": "DeepSeek-V4-Pro (ClinePass)",
+            "tooltip": "ClinePass — DeepSeek V4 Pro。1M 上下文，384K 输出，支持推理与工具调用，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1000000, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 384000,
+            "reasoningEffort": ["high", "xhigh"],
+            "reasoningFormat": "nested",
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "cline-pass/deepseek-v4-flash",
+            "name": "DeepSeek-V4-Flash (ClinePass)",
+            "tooltip": "ClinePass — DeepSeek V4 Flash。1M 上下文，384K 输出，支持推理与工具调用，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1000000, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 384000,
+            "reasoningEffort": ["high", "xhigh"],
+            "reasoningFormat": "nested",
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "cline-pass/mimo-v2.5",
+            "name": "MiMo-V2.5 (ClinePass)",
+            "tooltip": "ClinePass — MiMo-V2.5。1M 上下文，131K 输出，支持推理、工具调用与图片/音频/视频输入，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1048576, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1048576,
+            "maxOutputTokens": 131072,
+            "thinking": ["enabled", "disabled"],
+            "thinkingFormat": "object",
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        },
+        {
+            "id": "cline-pass/mimo-v2.5-pro",
+            "name": "MiMo-V2.5-Pro (ClinePass)",
+            "tooltip": "ClinePass — MiMo-V2.5-Pro。1M 上下文，131K 输出，支持推理与工具调用，纯文本模型，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1048576, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1048576,
+            "maxOutputTokens": 131072,
+            "thinking": ["enabled", "disabled"],
+            "thinkingFormat": "object",
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "cline-pass/minimax-m3",
+            "name": "MiniMax-M3 (ClinePass)",
+            "tooltip": "ClinePass — MiniMax M3。512K 上下文，128K 输出，支持推理、工具调用与图片/视频输入，开源。",
+            "sdkMode": "openai-sse",
+            "contextSize": [512000, 400000, 256000, 192000, 128000],
+            "maxInputTokens": 512000,
+            "maxOutputTokens": 128000,
+            "thinking": ["enabled", "disabled"],
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        },
+        {
+            "id": "cline-pass/qwen3.7-max",
+            "name": "Qwen3.7-Max (ClinePass)",
+            "tooltip": "ClinePass — Qwen3.7 Max。1M 上下文，65K 输出，支持推理与工具调用，纯文本模型。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1000000, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 65536,
+            "thinking": ["enabled", "disabled"],
+            "capabilities": { "toolCalling": true, "imageInput": false }
+        },
+        {
+            "id": "cline-pass/qwen3.7-plus",
+            "name": "Qwen3.7-Plus (ClinePass)",
+            "tooltip": "ClinePass — Qwen3.7 Plus。1M 上下文，64K 输出，支持推理、工具调用与图片输入。",
+            "sdkMode": "openai-sse",
+            "contextSize": [1000000, 600000, 400000, 256000, 192000],
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 64000,
+            "thinking": ["enabled", "disabled"],
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        }
+    ]
+}

--- a/src/providers/config/index.ts
+++ b/src/providers/config/index.ts
@@ -18,6 +18,7 @@ import codex from './codex.json';
 import grok from './grok.json';
 import opencode from './opencode.json';
 import hyper from './hyper.json';
+import clinepass from './clinepass.json';
 
 const providers = {
     zhipu,
@@ -37,7 +38,8 @@ const providers = {
     codex,
     grok,
     opencode,
-    hyper
+    hyper,
+    clinepass
 };
 
 export type ProviderName = keyof typeof providers;

--- a/src/sync/gistSyncService.ts
+++ b/src/sync/gistSyncService.ts
@@ -102,6 +102,7 @@ const KNOWN_KEY_LABELS: Record<string, string> = {
     stepfun: 'StepFun',
     opencode: 'OpenCode',
     hyper: 'Charm Hyper',
+    clinepass: 'ClinePass',
     // ── 多密钥变体 ──
     'minimax-token': 'MiniMax Token Plan',
     'dashscope-coding': 'DashScope Coding Plan',


### PR DESCRIPTION
- [核心逻辑] 新增 ClinePass 配置文件并完成模型列表与提供商映射注册
- [配置变更] 在 package.json 中配置激活事件与命令，并在同步服务中补充密钥标签
- [文档同步] 更新中英文 README 说明并同步添加相关命令的本地化翻译