### PR TITLE
feat: 新增 editTools 能力声明字段并应用于 GLM-5.2，让模型支持批量编辑的能力

### DIFF
--- a/src/providers/config/zhipu.json
+++ b/src/providers/config/zhipu.json
@@ -13,7 +13,7 @@
             "maxInputTokens": 1000000,
             "maxOutputTokens": 128000,
             "reasoningEffort": ["high", "max", "none"],
-            "capabilities": { "toolCalling": true, "imageInput": false }
+            "capabilities": { "toolCalling": true, "imageInput": false, "editTools": ["multi-find-replace", "find-replace", "code-rewrite"] }
         },
         {
             "id": "glm-5v-turbo",

--- a/src/types/sharedTypes.ts
+++ b/src/types/sharedTypes.ts
@@ -48,6 +48,12 @@ export interface ModelConfig {
     capabilities: {
         toolCalling: boolean;
         imageInput: boolean;
+        /**
+         * 模型偏好的编辑工具列表（透传到 VS Code LanguageModelChatCapabilities.editTools）
+         * 可选值：'find-replace' | 'multi-find-replace' | 'code-rewrite' | 'apply-patch' (其 V4A diff 仅适配 OpenAI 系列)
+         * 未设置时由 Copilot 走默认学习机制推断
+         */
+        editTools?: string[];
     };
     /**
      * SDK模式选择（可选）
@@ -192,6 +198,7 @@ export interface ModelOverride {
     capabilities?: {
         toolCalling?: boolean;
         imageInput?: boolean;
+        editTools?: string[];
     };
     /** 覆盖baseUrl */
     baseUrl?: string;


### PR DESCRIPTION
## 修改内容
- sharedTypes.ts: 在 ModelConfig.capabilities 与 ModelOverride.capabilities 新增可选 editTools 字段，对应 VS Code LanguageModelChatCapabilities.editTools
- zhipu.json: 为 glm-5.2 声明 editTools: [multi-find-replace, find-replace, code-rewrite]

## 修改原因
让 BYOK 模型可以显式声明偏好的编辑工具集，绕过 Copilot 默认的学习机制（其 Initial 状态不包含 multi_replace），从而在 Agent 编辑模式下获得更稳定、更高效的代码修改体验。
我使用GLM 5.2一段时间了，但学习机制一直是初始状态，不能使用批量编辑能力，一直是`replace_string_in_file`，故主动加上批量编辑的能力，实际测试模型能稳定使用`multi_replace_string_in_file`，提升了编辑的效率。

## 依据 
VS Code 官方文档 Model configuration reference 中 editTools 定义： https://code.visualstudio.com/docs/agent-customization/language-models#_model-configuration-reference.
editTools 可选值: find-replace | multi-find-replace | code-rewrite | apply-patch