### PR TITLE
feat: add Volcano Ark Kimi-K3 (AgentPlan) model

### DIFF
--- a/src/providers/config/volcengine.json
+++ b/src/providers/config/volcengine.json
@@ -291,6 +291,19 @@
             "capabilities": { "toolCalling": true, "imageInput": true }
         },
         {
+            "id": "ark-plan-kimi-k3",
+            "name": "Kimi-K3 (AgentPlan)",
+            "model": "kimi-k3",
+            "provider": "volcengine-agent",
+            "sdkMode": "anthropic",
+            "baseUrl": "https://ark.cn-beijing.volces.com/api/plan",
+            "tooltip": "Agent Plan 模型。月之暗面最新一代旗舰模型，支持 1M 上下文窗口，具备更强的推理、编程与 Agent 任务能力。默认 thinking，支持关闭深度思考。",
+            "maxInputTokens": 1000000,
+            "maxOutputTokens": 32000,
+            "thinking": ["enabled", "disabled"],
+            "capabilities": { "toolCalling": true, "imageInput": true }
+        },
+        {
             "id": "ark-plan-deepseek-v4-flash",
             "name": "DeepSeek-V4-Flash (AgentPlan)",
             "model": "deepseek-v4-flash",


### PR DESCRIPTION
## 概述

新增火山方舟 Agent Plan 中的 Kimi-K3 模型，支持 1M 上下文窗口。

## 改动内容

在 `src/providers/config/volcengine.json` 新增模型：

| 字段 | 值 |
|---|---|
| id | `ark-plan-kimi-k3` |
| name | Kimi-K3 (AgentPlan) |
| model | `kimi-k3` |
| provider | `volcengine-agent` |
| sdkMode | `anthropic` |
| baseUrl | `https://ark.cn-beijing.volces.com/api/plan` |
| maxInputTokens | 1000000（1M 上下文） |
| maxOutputTokens | 32000 |
| thinking | `["enabled", "disabled"]` |
| capabilities | 工具调用 + 图片输入 |

配置参照同系列 Kimi-K2.6/K2.7-Code 的 AgentPlan 模型，上下文窗口升级为 1M。

## 验证

- `tsc --noEmit` 退出码 0
- JSON 解析正常，模型已正确挂载到 `volcengine-agent` provider