### PR TITLE
fix: remove the editTools field from the Volcano Ark Agent Plan model

### DIFF
--- a/src/providers/config/volcengine.json
+++ b/src/providers/config/volcengine.json
@@ -287,7 +287,7 @@
             "maxInputTokens": 1000000,
             "maxOutputTokens": 64000,
             "reasoningEffort": ["max", "none"],
-            "capabilities": { "toolCalling": true, "imageInput": true, "editTools": true }
+            "capabilities": { "toolCalling": true, "imageInput": true }
         },
         {
             "id": "ark-plan-kimi-k2.7-code",
@@ -300,7 +300,7 @@
             "maxInputTokens": 224000,
             "maxOutputTokens": 32000,
             "extraBody": { "thinking": { "type": "enabled" } },
-            "capabilities": { "toolCalling": true, "imageInput": true, "editTools": true }
+            "capabilities": { "toolCalling": true, "imageInput": true }
         },
         {
             "id": "ark-plan-kimi-k2.6",
@@ -313,7 +313,7 @@
             "maxInputTokens": 224000,
             "maxOutputTokens": 32000,
             "thinking": ["enabled", "disabled"],
-            "capabilities": { "toolCalling": true, "imageInput": true, "editTools": true }
+            "capabilities": { "toolCalling": true, "imageInput": true }
         },
         {
             "id": "ark-plan-deepseek-v4-flash",


### PR DESCRIPTION
## 问题

0.25.42 版本（commit f819a40）为以下 3 个火山方舟 Agent Plan 模型添加了 `editTools: true`：

- `ark-plan-kimi-k3`
- `ark-plan-kimi-k2.7-code`
- `ark-plan-kimi-k2.6`

`editTools` 字段属于 `chatProvider` proposed API 中的 `LanguageModelChatCapabilities.editTools`，导致 volcengine provider 在注册这些模型时触发 VS Code 对 proposed API 的使用检查，报错：

> Extension 'vicanent.gcmp' CANNOT use API proposal: chatProvider

volcengine 的全部模型因此无法在模型选择器中显示，其他 provider 不受影响（因为它们在 0.25.42 之前已有 `editTools` 且 product.json 白名单已包含 `vicanent.gcmp`）。

## 修复

移除这 3 个模型的 `editTools: true` 字段，恢复为 0.25.41 时的配置：

```diff
- "capabilities": { "toolCalling": true, "imageInput": true, "editTools": true }
+ "capabilities": { "toolCalling": true, "imageInput": true }
```

## 验证

移除后 volcengine 模型恢复正常显示。