### PR TITLE
feat(grok): 展示订阅剩余额度

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -229,6 +229,8 @@ irm https://x.ai/cli/install.ps1 | iex
 ```
 
 - **Supported models**: See [config/grok.json](src/providers/config/grok.json).
+- **Usage tracking**: The status bar displays remaining Grok/SuperGrok subscription quota and reset time. Weekly quota is preferred; unified-billing accounts show monthly quota.
+- **Independent proxy settings**: Use `gcmp.providerOverrides.grok.proxy` for Grok requests. Set `GROK_CLI_CHAT_PROXY_BASE_URL` to override the Grok CLI billing service base URL.
 
 ## ⚙️ Advanced Configuration
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ irm https://x.ai/cli/install.ps1 | iex
 ```
 
 - **支持模型**：详见 [config/grok.json](src/providers/config/grok.json)。
+- **用量查询**：已支持状态栏显示 Grok/SuperGrok 订阅剩余额度与重置时间。优先展示每周额度；统一账单账户会展示月度额度。
+- **独立代理设置**：可通过 `gcmp.providerOverrides.grok.proxy` 指定 Grok 请求代理。自定义 Grok CLI billing 服务地址时，可设置环境变量 `GROK_CLI_CHAT_PROXY_BASE_URL`。
 
 ## ⚙️ 高级配置
 

--- a/src/cli/auth/grokAuthCredentials.test.ts
+++ b/src/cli/auth/grokAuthCredentials.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildRefreshedGrokCredentials } from './grokAuthCredentials';
+
+test('Grok token refresh preserves account metadata required by billing requests', () => {
+    const credentials = buildRefreshedGrokCredentials({
+        previous: {
+            access_token: 'old-access-token',
+            refresh_token: 'old-refresh-token',
+            expiry_date: 1,
+            oidc_client_id: 'client-id',
+            user_id: 'user-123',
+            email: 'dev@example.com',
+            team_id: 'team-456'
+        },
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiryDate: 2,
+        clientId: 'client-id'
+    });
+
+    assert.deepEqual(credentials, {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expiry_date: 2,
+        oidc_client_id: 'client-id',
+        user_id: 'user-123',
+        email: 'dev@example.com',
+        team_id: 'team-456'
+    });
+});
+
+test('Grok token refresh does not synthesize missing account metadata', () => {
+    const credentials = buildRefreshedGrokCredentials({
+        previous: {
+            access_token: 'old-access-token',
+            refresh_token: 'old-refresh-token',
+            expiry_date: 1
+        },
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiryDate: 2,
+        clientId: 'client-id'
+    });
+
+    assert.deepEqual(credentials, {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expiry_date: 2,
+        oidc_client_id: 'client-id'
+    });
+});

--- a/src/cli/auth/grokAuthCredentials.ts
+++ b/src/cli/auth/grokAuthCredentials.ts
@@ -1,0 +1,34 @@
+import type { OAuthCredentials } from '../type';
+
+export interface GrokOAuthCredentials extends OAuthCredentials {
+    oidc_client_id?: string;
+    user_id?: string;
+    email?: string;
+    team_id?: string;
+}
+
+interface BuildRefreshedGrokCredentialsInput {
+    previous: GrokOAuthCredentials;
+    accessToken: string;
+    refreshToken: string;
+    expiryDate: number;
+    clientId: string;
+}
+
+export function buildRefreshedGrokCredentials({
+    previous,
+    accessToken,
+    refreshToken,
+    expiryDate,
+    clientId
+}: BuildRefreshedGrokCredentialsInput): GrokOAuthCredentials {
+    return {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        expiry_date: expiryDate,
+        oidc_client_id: clientId,
+        ...(previous.user_id ? { user_id: previous.user_id } : {}),
+        ...(previous.email ? { email: previous.email } : {}),
+        ...(previous.team_id ? { team_id: previous.team_id } : {})
+    };
+}

--- a/src/cli/auth/grokCliAuth.ts
+++ b/src/cli/auth/grokCliAuth.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { BaseCliAuth } from './baseCliAuth';
 import { Logger } from '../../utils/runtime/logger';
 import type { CliAuthConfig, OAuthCredentials } from '../type';
+import { buildRefreshedGrokCredentials, type GrokOAuthCredentials } from './grokAuthCredentials';
 
 interface GrokAuthRecord {
     key?: string;
@@ -15,10 +16,6 @@ interface GrokAuthRecord {
     expires_at?: string;
     oidc_client_id?: string;
     [key: string]: unknown;
-}
-
-interface GrokOAuthCredentials extends OAuthCredentials {
-    oidc_client_id?: string;
 }
 
 const GROK_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828';
@@ -149,12 +146,13 @@ export class GrokCliAuth extends BaseCliAuth {
                 Date.now() + (expiresIn as number) * 1000
             :   this.extractExpFromJwt(accessToken) || credentials.expiry_date || Date.now() + 55 * 60 * 1000;
 
-        const newCredentials: GrokOAuthCredentials = {
-            access_token: accessToken,
-            refresh_token: refreshToken,
-            expiry_date: expiryDate,
-            oidc_client_id: clientId
-        };
+        const newCredentials = buildRefreshedGrokCredentials({
+            previous: extendedCredentials,
+            accessToken,
+            refreshToken,
+            expiryDate,
+            clientId
+        });
 
         this.saveCredentials(newCredentials);
         Logger.info('[Grok Build] Token refresh succeeded');
@@ -178,6 +176,9 @@ export class GrokCliAuth extends BaseCliAuth {
             access_token: accessToken,
             refresh_token: typeof record.refresh_token === 'string' ? record.refresh_token : '',
             expiry_date: expiryFromToken || expiryFromFile || 0,
+            ...(typeof record.user_id === 'string' && record.user_id ? { user_id: record.user_id } : {}),
+            ...(typeof record.email === 'string' && record.email ? { email: record.email } : {}),
+            ...(typeof record.team_id === 'string' && record.team_id ? { team_id: record.team_id } : {}),
             ...(typeof record.oidc_client_id === 'string' && record.oidc_client_id ?
                 { oidc_client_id: record.oidc_client_id }
             :   {})

--- a/src/status/grokStatusBar.ts
+++ b/src/status/grokStatusBar.ts
@@ -1,0 +1,221 @@
+/*---------------------------------------------------------------------------------------------
+ *  Grok 用量查询状态栏项
+ *  使用 Grok CLI OAuth 登录态显示 SuperGrok/Grok 订阅剩余额度
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { BaseStatusBarItem, StatusBarItemConfig } from './baseStatusBarItem';
+import { CliAuthFactory } from '../cli/auth/cliAuthFactory';
+import { ConfigManager } from '../utils/config/configManager';
+import { Logger } from '../utils/runtime/logger';
+import { StatusLogger } from '../utils/runtime/statusLogger';
+import { t } from '../utils/runtime/l10n';
+import { GrokBillingParseResult, GrokUsageLimit, parseGrokBillingUsage, resolveGrokBillingBaseUrl } from './grokUsage';
+
+interface GrokCredentials {
+    access_token: string;
+    user_id?: string;
+}
+
+export interface GrokStatusData {
+    usage: GrokUsageLimit;
+    lastUpdated: string;
+}
+
+type BillingRequestResult = { kind: 'parsed'; result: GrokBillingParseResult } | { kind: 'error'; error: string };
+
+export class GrokStatusBar extends BaseStatusBarItem<GrokStatusData> {
+    constructor() {
+        const config: StatusBarItemConfig = {
+            id: 'gcmp.statusBar.grok',
+            name: 'GCMP: Grok Usage',
+            alignment: vscode.StatusBarAlignment.Right,
+            priority: 14,
+            refreshCommand: 'gcmp.grok.refreshUsage',
+            apiKeyProvider: 'grok',
+            cacheKeyPrefix: 'grok',
+            logPrefix: 'Grok Status Bar',
+            icon: '𝕏'
+        };
+        super(config);
+    }
+
+    protected getDisplayText(data: GrokStatusData): string {
+        return `${this.config.icon} ${data.usage.remainingPercent.toFixed(0)}%`;
+    }
+
+    protected generateTooltip(data: GrokStatusData): vscode.MarkdownString {
+        const md = new vscode.MarkdownString();
+        const tier = data.usage.subscriptionTier ? ` ${data.usage.subscriptionTier}` : '';
+        const windowLabel =
+            data.usage.type === 'weekly' ? t('Weekly quota', '每周额度') : t('Monthly quota', '每月额度');
+        const countdown = this.formatCountdown(data.usage.resetAt);
+        const resetTime = data.usage.resetAt ? this.formatDateTime(new Date(data.usage.resetAt)) : '—';
+
+        md.appendMarkdown(`#### Grok${tier}\n\n`);
+        md.appendMarkdown(
+            `| ${t('Window', '限频类型')} | ${t('Remaining', '剩余量')} | ${t('Countdown', '倒计时')} | ${t('Reset Time', '重置时间')} |\n`
+        );
+        md.appendMarkdown('| :----: | ----: | ----: | :------: |\n');
+        md.appendMarkdown(
+            `| **${windowLabel}** | **${data.usage.remainingPercent.toFixed(0)}%** | ${countdown} | ${resetTime} |\n`
+        );
+        md.appendMarkdown('\n---\n');
+        md.appendMarkdown(`**${t('Last updated', '最后更新')}** ${data.lastUpdated}\n`);
+        md.appendMarkdown('\n---\n');
+        md.appendMarkdown(`${t('Click the status bar to refresh manually', '点击状态栏可手动刷新')}\n`);
+        return md;
+    }
+
+    protected shouldHighlightWarning(data: GrokStatusData): boolean {
+        return data.usage.usedPercent >= this.HIGH_USAGE_THRESHOLD;
+    }
+
+    protected shouldRefresh(): boolean {
+        if (!this.lastStatusData) {
+            return true;
+        }
+        return super.shouldRefresh();
+    }
+
+    protected async performApiQuery(): Promise<{ success: boolean; data?: GrokStatusData; error?: string }> {
+        try {
+            const credentials = (await CliAuthFactory.ensureAuthenticated('grok')) as GrokCredentials | null;
+            if (!credentials?.access_token) {
+                return {
+                    success: false,
+                    error: t(
+                        'Grok CLI authentication is invalid. Sign in to Grok CLI first.',
+                        'Grok CLI 认证无效，请先完成 Grok CLI 登录'
+                    )
+                };
+            }
+
+            StatusLogger.debug(`[${this.config.logPrefix}] Starting Grok usage query...`);
+            const creditsResult = await this.requestBillingUsage(credentials, '?format=credits', 'credits');
+            if (creditsResult.kind === 'error') {
+                return { success: false, error: creditsResult.error };
+            }
+
+            let parsedResult = creditsResult.result;
+            const creditsSubscriptionTier =
+                parsedResult.kind === 'unavailable' ? parsedResult.subscriptionTier : undefined;
+            if (parsedResult.kind === 'unavailable') {
+                const monthlyResult = await this.requestBillingUsage(credentials, '', 'billing');
+                if (monthlyResult.kind === 'error') {
+                    return { success: false, error: monthlyResult.error };
+                }
+                parsedResult = monthlyResult.result;
+            }
+
+            if (parsedResult.kind === 'invalid') {
+                return {
+                    success: false,
+                    error: t('Invalid Grok usage response: {0}', 'Grok 用量响应无效: {0}', parsedResult.error)
+                };
+            }
+            if (parsedResult.kind === 'unavailable') {
+                return {
+                    success: false,
+                    error: t(
+                        'No Grok subscription quota was returned for this account.',
+                        '当前 Grok 账户未返回订阅额度'
+                    )
+                };
+            }
+
+            const usage =
+                !parsedResult.usage.subscriptionTier && creditsSubscriptionTier ?
+                    { ...parsedResult.usage, subscriptionTier: creditsSubscriptionTier }
+                :   parsedResult.usage;
+            return {
+                success: true,
+                data: {
+                    usage,
+                    lastUpdated: new Date().toLocaleString(
+                        vscode.env.language.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US'
+                    )
+                }
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            Logger.error(`Grok usage query failed: ${errorMessage}`);
+            return {
+                success: false,
+                error: t('Query failed: {0}', '查询失败: {0}', errorMessage)
+            };
+        }
+    }
+
+    protected async shouldShowStatusBar(): Promise<boolean> {
+        const credentials = await CliAuthFactory.loadCredentials('grok');
+        return typeof credentials?.access_token === 'string' && credentials.access_token.length > 0;
+    }
+
+    private async requestBillingUsage(
+        credentials: GrokCredentials,
+        query: string,
+        source: 'credits' | 'billing'
+    ): Promise<BillingRequestResult> {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        const headers: Record<string, string> = {
+            Authorization: `Bearer ${credentials.access_token}`,
+            'X-XAI-Token-Auth': 'xai-grok-cli',
+            Accept: 'application/json'
+        };
+        if (credentials.user_id) {
+            headers['x-userid'] = credentials.user_id;
+        }
+
+        try {
+            const baseUrl = resolveGrokBillingBaseUrl(process.env);
+            const response = await ConfigManager.fetchWithProxy(
+                `${baseUrl}/billing${query}`,
+                {
+                    method: 'GET',
+                    headers,
+                    signal: controller.signal
+                },
+                {
+                    providerKey: 'grok'
+                }
+            );
+            const responseText = await response.text();
+
+            StatusLogger.debug(
+                `[${this.config.logPrefix}] Usage query response status: ${response.status} ${response.statusText}`
+            );
+
+            if (!response.ok) {
+                const authorizationMessage =
+                    response.status === 401 || response.status === 403 ?
+                        t('Grok CLI authorization was rejected. Sign in again.', 'Grok CLI 授权被拒绝，请重新登录')
+                    :   t('Grok usage query failed with HTTP {0}.', 'Grok 用量查询失败，HTTP {0}', response.status);
+                return { kind: 'error', error: authorizationMessage };
+            }
+
+            let payload: unknown;
+            try {
+                payload = JSON.parse(responseText);
+            } catch {
+                return {
+                    kind: 'error',
+                    error: t('Grok usage response is not valid JSON.', 'Grok 用量响应不是有效 JSON')
+                };
+            }
+
+            return { kind: 'parsed', result: parseGrokBillingUsage(payload, source) };
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    private formatDateTime(date: Date): string {
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${month}/${day} ${hours}:${minutes}`;
+    }
+}

--- a/src/status/grokUsage.test.ts
+++ b/src/status/grokUsage.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseGrokBillingUsage, resolveGrokBillingBaseUrl } from './grokUsage';
+
+test('credits billing converts Grok weekly used percent into the remaining quota', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                creditUsagePercent: 37.25,
+                subscriptionTier: 'SuperGrok',
+                currentPeriod: {
+                    type: 'USAGE_PERIOD_TYPE_WEEKLY',
+                    start: '2026-07-27T00:00:00.000Z',
+                    end: '2026-08-03T00:00:00.000Z'
+                },
+                billingPeriodStart: '2026-07-27T00:00:00.000Z',
+                billingPeriodEnd: '2026-08-03T00:00:00.000Z'
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'usage',
+        usage: {
+            type: 'weekly',
+            usedPercent: 37.25,
+            remainingPercent: 62.75,
+            resetAt: '2026-08-03T00:00:00.000Z',
+            windowMinutes: 10080,
+            subscriptionTier: 'SuperGrok'
+        }
+    });
+});
+
+test('credits billing treats an omitted protobuf zero as zero usage only for an exact weekly period', () => {
+    const periodStart = '2026-07-27T00:00:00.000Z';
+    const periodEnd = '2026-08-03T00:00:00.000Z';
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                currentPeriod: {
+                    type: 'USAGE_PERIOD_TYPE_WEEKLY',
+                    start: periodStart,
+                    end: periodEnd
+                },
+                billingPeriodStart: periodStart,
+                billingPeriodEnd: periodEnd
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'usage',
+        usage: {
+            type: 'weekly',
+            usedPercent: 0,
+            remainingPercent: 100,
+            resetAt: periodEnd,
+            windowMinutes: 10080
+        }
+    });
+});
+
+test('credits billing does not report ambiguous omitted usage as a full weekly quota', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                currentPeriod: {
+                    type: 'USAGE_PERIOD_TYPE_WEEKLY',
+                    start: '2026-07-01T00:00:00.000Z',
+                    end: '2026-07-08T00:00:00.000Z'
+                },
+                billingPeriodStart: '2026-07-01T00:00:00.000Z',
+                billingPeriodEnd: '2026-08-01T00:00:00.000Z'
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, { kind: 'unavailable' });
+});
+
+test('credits billing keeps the subscription tier for a monthly fallback response', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                subscriptionTier: 'SuperGrok',
+                isUnifiedBillingUser: true
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'unavailable',
+        subscriptionTier: 'SuperGrok'
+    });
+});
+
+test('unified billing converts string monthly amounts into a remaining percentage', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                monthlyLimit: { val: '200' },
+                used: { val: '50' },
+                billingPeriodEnd: '2026-08-31T23:59:59.000Z',
+                subscriptionTier: 'SuperGrok Heavy'
+            }
+        },
+        'billing'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'usage',
+        usage: {
+            type: 'monthly',
+            usedPercent: 25,
+            remainingPercent: 75,
+            resetAt: '2026-08-31T23:59:59.000Z',
+            windowMinutes: 43200,
+            subscriptionTier: 'SuperGrok Heavy'
+        }
+    });
+});
+
+test('billing rejects malformed numeric fields instead of silently replacing business values', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                creditUsagePercent: '37',
+                billingPeriodEnd: '2026-08-03T00:00:00.000Z'
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'invalid',
+        error: 'creditUsagePercent must be a finite number'
+    });
+});
+
+test('billing preserves an overage while flooring the remaining quota at zero', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                monthlyLimit: { val: 100 },
+                used: { val: 125 },
+                billingPeriodEnd: '2026-08-31T23:59:59.000Z'
+            }
+        },
+        'billing'
+    );
+
+    assert.equal(result.kind, 'usage');
+    if (result.kind === 'usage') {
+        assert.equal(result.usage.usedPercent, 125);
+        assert.equal(result.usage.remainingPercent, 0);
+    }
+});
+
+test('credits billing rejects a negative used percentage', () => {
+    const result = parseGrokBillingUsage(
+        {
+            config: {
+                creditUsagePercent: -1,
+                billingPeriodEnd: '2026-08-03T00:00:00.000Z'
+            }
+        },
+        'credits'
+    );
+
+    assert.deepEqual(result, {
+        kind: 'invalid',
+        error: 'creditUsagePercent must not be negative'
+    });
+});
+
+test('billing base URL honors the Grok CLI override and removes trailing slashes', () => {
+    assert.equal(
+        resolveGrokBillingBaseUrl({ GROK_CLI_CHAT_PROXY_BASE_URL: ' https://proxy.example.test/v2/// ' }),
+        'https://proxy.example.test/v2'
+    );
+    assert.equal(resolveGrokBillingBaseUrl({}), 'https://cli-chat-proxy.grok.com/v1');
+});

--- a/src/status/grokUsage.ts
+++ b/src/status/grokUsage.ts
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------------------------
+ *  Grok 订阅用量响应解析
+ *  将 Grok CLI billing API 的每周额度和统一账单月度额度转换为统一展示模型
+ *--------------------------------------------------------------------------------------------*/
+
+const DEFAULT_GROK_BILLING_BASE_URL = 'https://cli-chat-proxy.grok.com/v1';
+const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+const MONTHLY_WINDOW_MINUTES = 30 * 24 * 60;
+
+type BillingSource = 'credits' | 'billing';
+
+export interface GrokUsageLimit {
+    type: 'weekly' | 'monthly';
+    usedPercent: number;
+    remainingPercent: number;
+    resetAt?: string;
+    windowMinutes: number;
+    subscriptionTier?: string;
+}
+
+export type GrokBillingParseResult =
+    | { kind: 'usage'; usage: GrokUsageLimit }
+    | { kind: 'unavailable'; subscriptionTier?: string }
+    | { kind: 'invalid'; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseDate(value: unknown): { iso: string; timestamp: number } | undefined {
+    if (typeof value !== 'string' || value.length === 0) {
+        return undefined;
+    }
+
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp)) {
+        return undefined;
+    }
+
+    return { iso: value, timestamp };
+}
+
+function getResetAt(config: Record<string, unknown>): string | undefined {
+    const currentPeriod = isRecord(config.currentPeriod) ? config.currentPeriod : undefined;
+    if (currentPeriod && hasOwn(currentPeriod, 'end')) {
+        return parseDate(currentPeriod.end)?.iso;
+    }
+
+    return parseDate(config.billingPeriodEnd)?.iso;
+}
+
+function getSubscriptionTier(config: Record<string, unknown>): string | undefined {
+    return typeof config.subscriptionTier === 'string' && config.subscriptionTier.length > 0 ?
+            config.subscriptionTier
+        :   undefined;
+}
+
+function getBillingConfig(payload: unknown, source: BillingSource): Record<string, unknown> | undefined {
+    if (!isRecord(payload)) {
+        return undefined;
+    }
+
+    if (isRecord(payload.config)) {
+        return payload.config;
+    }
+
+    // Grok 的 credits 端点曾直接返回 config 字段；仅在明确带有 creditUsagePercent 时兼容该结构。
+    if (source === 'credits' && hasOwn(payload, 'creditUsagePercent')) {
+        return payload;
+    }
+
+    return undefined;
+}
+
+function isExplicitWeeklyZero(config: Record<string, unknown>): boolean {
+    if (!isRecord(config.currentPeriod)) {
+        return false;
+    }
+
+    const currentPeriod = config.currentPeriod;
+    if (currentPeriod.type !== 'USAGE_PERIOD_TYPE_WEEKLY') {
+        return false;
+    }
+
+    const periodStart = parseDate(currentPeriod.start);
+    const periodEnd = parseDate(currentPeriod.end);
+    const billingStart = parseDate(config.billingPeriodStart);
+    const billingEnd = parseDate(config.billingPeriodEnd);
+
+    return (
+        periodStart !== undefined &&
+        periodEnd !== undefined &&
+        billingStart !== undefined &&
+        billingEnd !== undefined &&
+        periodStart.timestamp === billingStart.timestamp &&
+        periodEnd.timestamp === billingEnd.timestamp
+    );
+}
+
+function parseWeeklyUsage(config: Record<string, unknown>): GrokBillingParseResult {
+    let usedPercent: number;
+    if (hasOwn(config, 'creditUsagePercent')) {
+        if (typeof config.creditUsagePercent !== 'number' || !Number.isFinite(config.creditUsagePercent)) {
+            return { kind: 'invalid', error: 'creditUsagePercent must be a finite number' };
+        }
+        if (config.creditUsagePercent < 0) {
+            return { kind: 'invalid', error: 'creditUsagePercent must not be negative' };
+        }
+        usedPercent = config.creditUsagePercent;
+    } else if (isExplicitWeeklyZero(config)) {
+        // protobuf JSON 会省略数值 0。仅当 weekly period 与 billing period 完全一致时才能确认这是 0% 已用。
+        usedPercent = 0;
+    } else {
+        const subscriptionTier = getSubscriptionTier(config);
+        return {
+            kind: 'unavailable',
+            ...(subscriptionTier ? { subscriptionTier } : {})
+        };
+    }
+
+    const resetAt = getResetAt(config);
+    const subscriptionTier = getSubscriptionTier(config);
+    return {
+        kind: 'usage',
+        usage: {
+            type: 'weekly',
+            usedPercent,
+            remainingPercent: Math.max(0, 100 - usedPercent),
+            ...(resetAt ? { resetAt } : {}),
+            windowMinutes: WEEKLY_WINDOW_MINUTES,
+            ...(subscriptionTier ? { subscriptionTier } : {})
+        }
+    };
+}
+
+function parseAmount(value: unknown, fieldName: string): { value: number } | { error: string } | undefined {
+    if (!isRecord(value) || !hasOwn(value, 'val')) {
+        return undefined;
+    }
+
+    const rawValue = value.val;
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+        return { value: rawValue };
+    }
+
+    if (typeof rawValue === 'string' && rawValue.trim().length > 0) {
+        const parsed = Number(rawValue);
+        if (Number.isFinite(parsed)) {
+            return { value: parsed };
+        }
+    }
+
+    return { error: `${fieldName}.val must be a finite number or numeric string` };
+}
+
+function parseMonthlyUsage(config: Record<string, unknown>): GrokBillingParseResult {
+    const limitResult = parseAmount(config.monthlyLimit, 'monthlyLimit');
+    const usedResult = parseAmount(config.used, 'used');
+
+    if (!limitResult || !usedResult) {
+        const subscriptionTier = getSubscriptionTier(config);
+        return {
+            kind: 'unavailable',
+            ...(subscriptionTier ? { subscriptionTier } : {})
+        };
+    }
+    if ('error' in limitResult) {
+        return { kind: 'invalid', error: limitResult.error };
+    }
+    if ('error' in usedResult) {
+        return { kind: 'invalid', error: usedResult.error };
+    }
+    if (limitResult.value <= 0) {
+        return { kind: 'invalid', error: 'monthlyLimit.val must be greater than zero' };
+    }
+    if (usedResult.value < 0) {
+        return { kind: 'invalid', error: 'used.val must not be negative' };
+    }
+
+    const usedPercent = (usedResult.value / limitResult.value) * 100;
+    const resetAt = getResetAt(config);
+    const subscriptionTier = getSubscriptionTier(config);
+    return {
+        kind: 'usage',
+        usage: {
+            type: 'monthly',
+            usedPercent,
+            remainingPercent: Math.max(0, 100 - usedPercent),
+            ...(resetAt ? { resetAt } : {}),
+            windowMinutes: MONTHLY_WINDOW_MINUTES,
+            ...(subscriptionTier ? { subscriptionTier } : {})
+        }
+    };
+}
+
+export function parseGrokBillingUsage(payload: unknown, source: BillingSource): GrokBillingParseResult {
+    const config = getBillingConfig(payload, source);
+    if (!config) {
+        return { kind: 'unavailable' };
+    }
+
+    return source === 'credits' ? parseWeeklyUsage(config) : parseMonthlyUsage(config);
+}
+
+export function resolveGrokBillingBaseUrl(env: NodeJS.ProcessEnv): string {
+    const configuredUrl = env.GROK_CLI_CHAT_PROXY_BASE_URL?.trim();
+    if (!configuredUrl) {
+        return DEFAULT_GROK_BILLING_BASE_URL;
+    }
+
+    return configuredUrl.replace(/\/+$/, '');
+}

--- a/src/status/statusBarManager.ts
+++ b/src/status/statusBarManager.ts
@@ -11,6 +11,7 @@ import { DeepSeekStatusBar } from './deepseekStatusBar';
 import { MoonshotStatusBar } from './moonshotStatusBar';
 import { ZhipuStatusBar } from './zhipuStatusBar';
 import { ChatGPTStatusBar } from './chatgptStatusBar';
+import { GrokStatusBar } from './grokStatusBar';
 import { CompatibleStatusBar } from './compatibleStatusBar';
 import { ContextUsageStatusBar } from './contextUsageStatusBar';
 import { TokenUsageStatusBar } from './tokenUsageStatusBar';
@@ -50,6 +51,8 @@ export class StatusBarManager {
     static zhipu: IStatusBar | undefined;
     /** Codex 用量查询状态栏 */
     static codex: IStatusBar | undefined;
+    /** Grok 用量查询状态栏 */
+    static grok: IStatusBar | undefined;
     /** ClinePass 用量查询状态栏 */
     static clinepass: IStatusBar | undefined;
     /** Compatible 提供商状态栏 */
@@ -91,6 +94,10 @@ export class StatusBarManager {
         // 创建并注册 Codex 状态栏
         const chatgptStatusBar = new ChatGPTStatusBar();
         this.registerStatusBar('codex', chatgptStatusBar);
+
+        // 创建并注册 Grok 状态栏
+        const grokStatusBar = new GrokStatusBar();
+        this.registerStatusBar('grok', grokStatusBar);
 
         // 创建并注册 ClinePass 状态栏
         const clinepassStatusBar = new ClinePassStatusBar();
@@ -140,6 +147,9 @@ export class StatusBarManager {
                 break;
             case 'codex':
                 this.codex = statusBar;
+                break;
+            case 'grok':
+                this.grok = statusBar;
                 break;
             case 'clinepass':
                 this.clinepass = statusBar;
@@ -263,6 +273,7 @@ export class StatusBarManager {
         this.deepseek = undefined;
         this.moonshot = undefined;
         this.codex = undefined;
+        this.grok = undefined;
         this.clinepass = undefined;
         this.compatible = undefined;
         this.contextUsage = undefined;


### PR DESCRIPTION
## 内容

- 新增 Grok/SuperGrok 订阅余量状态栏，展示剩余量、套餐、周期和重置时间。
- 优先查询每周 credits 额度；统一账单账户在未返回周额度时查询月度额度。
- 保留 Grok OAuth 的账户元数据，确保账单请求携带 `x-userid`。

## 原因

现有扩展已支持 ChatGPT Plus 订阅余量，Grok Build 登录态缺少相应展示。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`（180 项通过）
