### PR TITLE
fix: jsonValidation 排除默认设置编辑器，避免 schema 误挂载

### DIFF
--- a/package.json
+++ b/package.json
@@ -907,7 +907,10 @@
         },
         "jsonValidation": [
             {
-                "fileMatch": "settings.json",
+                "fileMatch": [
+                    "settings.json",
+                    "!vscode://defaultsettings/*.json"
+                ],
                 "url": "gcmp-settings://root/schema.json"
             }
         ],


### PR DESCRIPTION
## 问题

`jsonValidation` 的 `fileMatch: "settings.json"` 会被 JSON 语言服务规范化为 `**/settings.json`，匹配任意位置、任意 scheme 下的同名文件——包括只读的默认设置编辑器（`vscode://defaultsettings/settings.json`），导致 GCMP 的动态配置 schema 被挂载到不该出现的地方。

<img width="694" height="498" alt="截屏2026-08-04 17 49 47" src="https://github.com/user-attachments/assets/eb6244a9-818b-4a33-acfd-fa1c53b2cd4d" />

## 改动

保留对真实 settings 文件的全量匹配，仅追加一条排除规则：

```json
"fileMatch": [
    "settings.json",
    "!vscode://defaultsettings/*.json"
]
```

- 排除模式（`!` 前缀）是 `jsonValidation` 贡献点官方支持的特性
- 语言服务侧语义为"最后命中的 pattern 生效"：默认设置编辑器先命中 `settings.json` 再命中排除项，不再挂载 GCMP schema
- 用户设置 / 工作区 `.vscode/settings.json` / Profile 设置 / 远程设置的提示与校验不受影响

## 验证

Reload Window 后：
- 用户/工作区 `settings.json` 中 `gcmp.*` 配置的补全与校验正常
- "首选项: 打开默认设置 (JSON)" 中不再挂载 GCMP schema

## 参考

https://github.com/microsoft/vscode/blob/360d5ce13f1dfd46467d4a366ea9e21e227a2547/extensions/configuration-editing/package.json#L87-L90

