### PR TITLE
fix: include 被显式接管时不再以明文回传历史思维链 (#345)

### DIFF
--- a/src/handlers/openai/encryptedReasoning.test.ts
+++ b/src/handlers/openai/encryptedReasoning.test.ts
@@ -1,7 +1,7 @@
 ﻿import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { isEncryptedReasoningEnabled } from './encryptedReasoning';
+import { isEncryptedReasoningEnabled, isIncludeOverridden } from './encryptedReasoning';
 
 test('未接管 include：gpt 模型且配置 extraBody.reasoning 时启用', () => {
     assert.equal(
@@ -63,4 +63,16 @@ test('接管 include：include 不含目标条目时不启用', () => {
         }),
         false
     );
+});
+
+test('isIncludeOverridden：定义 include 键（含 null/[]）即视为接管', () => {
+    assert.equal(isIncludeOverridden({ include: null }), true);
+    assert.equal(isIncludeOverridden({ include: [] }), true);
+    assert.equal(isIncludeOverridden({ include: ['reasoning.encrypted_content'] }), true);
+});
+
+test('isIncludeOverridden：未定义 include 键时不视为接管', () => {
+    assert.equal(isIncludeOverridden({ reasoning: { effort: 'medium' } }), false);
+    assert.equal(isIncludeOverridden({}), false);
+    assert.equal(isIncludeOverridden(undefined), false);
 });

--- a/src/handlers/openai/encryptedReasoning.ts
+++ b/src/handlers/openai/encryptedReasoning.ts
@@ -25,9 +25,22 @@ export function isEncryptedReasoningEnabled(params: {
     extraBody?: Record<string, unknown>;
 }): boolean {
     const { requestModel, extraBody } = params;
-    if (extraBody != null && 'include' in extraBody) {
-        const include = extraBody.include;
+    if (isIncludeOverridden(extraBody)) {
+        const include = extraBody!.include;
         return Array.isArray(include) && include.includes(ENCRYPTED_REASONING_INCLUDE);
     }
     return requestModel.toLowerCase().includes('gpt') && !!extraBody?.reasoning;
+}
+
+/**
+ * 判定 include 是否已被用户在 extraBody 中显式接管（定义了 include 键，含 null/[]）。
+ *
+ * 接管即用户已明确表达对思考项回传的意图：此时若密文回放未启用
+ * （isEncryptedReasoningEnabled 为 false），历史思维链的明文文本同样不应回传——
+ * GPT/Azure 端点要求输入端 reasoning 项 content 必须为空，回传 reasoning_text 会得到 400：
+ * "Invalid 'input[N].content': array too long. Expected an array with maximum length 0"。
+ * 未接管时保持既有行为：无密文端点（DeepSeek 等）继续以明文回传思维链。
+ */
+export function isIncludeOverridden(extraBody?: Record<string, unknown>): boolean {
+    return extraBody != null && 'include' in extraBody;
 }

--- a/src/handlers/openai/openaiResponsesMessageConverter.ts
+++ b/src/handlers/openai/openaiResponsesMessageConverter.ts
@@ -7,7 +7,7 @@ import { sanitizeToolSchema } from '../../utils/text/schemaSanitizer';
 import { decodeStatefulMarker } from '../statefulMarker';
 import { CustomDataPartMimeTypes, GCMP_SYSTEM_MESSAGE_NAME } from '../types';
 import type { OpenAIHandler } from '../openaiHandler';
-import { isEncryptedReasoningEnabled } from './encryptedReasoning';
+import { isEncryptedReasoningEnabled, isIncludeOverridden } from './encryptedReasoning';
 import { OpenAIResponsesCallIdResolver } from './openaiResponsesCallIdResolver';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
@@ -52,6 +52,13 @@ export class OpenAIResponsesMessageConverter {
                 requestModel: modelConfig.model || modelConfig.id,
                 extraBody: modelConfig.extraBody
             });
+        // include 被显式接管（如 { include: null }）且密文回放关闭时，明文思考文本同样不回传：
+        // GPT/Azure 端点要求输入端 reasoning 项 content 为空，回传 reasoning_text 会 400
+        // （"Invalid 'input[N].content': array too long"），且摘要入档后该会话每轮必失败。
+        // 未接管时保持既有行为：DeepSeek 等无密文端点继续以明文回传思维链。
+        const replayPlainThinking =
+            !replayEncryptedReasoning &&
+            !(modelConfig !== undefined && isIncludeOverridden(modelConfig.extraBody));
 
         for (const [messageIndex, message] of messages.entries()) {
             let role = this.mapRole(message.role);
@@ -139,7 +146,7 @@ export class OpenAIResponsesMessageConverter {
                         }
                         out.push(reasoningItem as unknown as ResponseReasoningItem);
                     }
-                } else {
+                } else if (replayPlainThinking) {
                     // 明文通道（DeepSeek 等无密文端点）：思维链文本以明文 reasoning 项回传，
                     // 端点将明文 content 归并到相邻 assistant 消息
                     const markerThinking = (this.getCompleteThinkingFromMarker(message.content) ?? '').trim();


### PR DESCRIPTION
## 问题

跟进 #345 评论区报告的伴生问题：`extraBody.include: null` 关闭密文回放后，若同时配置了 `reasoning.summary`（如 `"auto"`），上一轮产出的思考摘要文本会走明文通道、以 `reasoning_text` content 回传：

```json
{"type": "reasoning", "summary": [], "content": [{"type": "reasoning_text", "text": "..."}]}
```

GPT/Azure 端点要求输入端 reasoning 项 content 为空，直接 400：

```
Invalid 'input[N].content': array too long. Expected an array with maximum length 0,
but got an array with length 1 instead.
```

特征是**延迟一轮爆发**（摘要第 N 轮产生、第 N+1 轮回传才报错），且摘要一旦入档，该会话每轮必失败，叠加客户端自动重试会形成重试风暴。

## 修复

将「用户显式接管 include」的判定从 `isEncryptedReasoningEnabled` 中拆出为独立的 `isIncludeOverridden`（extraBody 定义了 `include` 键即视为接管，含 `null`/`[]`）：

- **接管且密文回放关闭**（即 `include: null` 场景）：明文思维链同样不回传——用户已明确表达"不要思考项回传"的意图；
- **未接管**：行为完全不变，DeepSeek 等接受明文 `reasoning_text` 的端点继续按原逻辑回传。

改动集中在 `openaiResponsesMessageConverter` 的 assistant 分支门控，`else` → `else if (replayPlainThinking)`，共 3 个文件 +37/-5。

## 测试

- `encryptedReasoning.test.ts` 追加 `isIncludeOverridden` 的两组用例；
- 已在真实环境验证（0.26.24 + Azure gpt-5.6-sol 多资源中转，20 万 token 会话 / 52 工具 / 多步 agent 链）：等效补丁应用后 `include: null` + `summary` 组合不再触发上述 400。

Closes 部分 #345（明文回传项）；`include: null` 对密文的处理在 0.26.24 已验证有效，再次感谢快速响应。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
