### PR TITLE
fix(retry): treat HTTP 408 Request Timeout as retryable transient error

### DIFF
--- a/src/utils/retry/retryClassifier.test.ts
+++ b/src/utils/retry/retryClassifier.test.ts
@@ -265,3 +265,61 @@ test('skipPermanentCheck makes top-level usage_limit_reached code retryable', ()
         true
     );
 });
+
+// 408 Request Timeout：上游处理超时（如 HuggingFace inference 冷启动），属瞬时错误应重试
+
+test('treats HTTP 408 status as retryable transient timeout', () => {
+    assert.equal(isRateLimitLikeError({ status: 408, message: 'Request Timeout' }), true);
+});
+
+test('treats HTTP 408 statusCode as retryable transient timeout', () => {
+    assert.equal(isRateLimitLikeError({ statusCode: 408, message: 'Request Timeout' }), true);
+});
+
+test('treats nested 408 status through cause chain as retryable', () => {
+    assert.equal(
+        isRateLimitLikeError({
+            message: 'Compatible Provider request processing failed',
+            cause: { status: 408, message: 'Upstream error: 408' }
+        }),
+        true
+    );
+});
+
+test('permanent error overrides HTTP 408 status', () => {
+    assert.equal(
+        isRateLimitLikeError({
+            status: 408,
+            message: 'Request exceeds the maximum context length limit of this model'
+        }),
+        false
+    );
+});
+
+// message 兜底：status 字段丢失时（如网关透传 "Upstream error: 408"），从消息文案识别 408
+
+test('treats message-only "Upstream error: 408" as retryable (status lost in transit)', () => {
+    assert.equal(isRateLimitLikeError({ message: 'Upstream error: 408' }), true);
+});
+
+test('treats message-only "Request Timeout" without 408 digit as not retryable by status', () => {
+    // 纯文案 "Request Timeout" 不含状态码数字，不命中 status / message-digit 兜底
+    assert.equal(isRateLimitLikeError({ message: 'Request Timeout' }), false);
+});
+
+test('treats nested message-only 408 through cause chain as retryable', () => {
+    assert.equal(
+        isRateLimitLikeError({
+            message: 'Compatible Provider request processing failed',
+            cause: { message: 'Upstream error: 408' }
+        }),
+        true
+    );
+});
+
+test('skipPermanentCheck does not affect 408 (not a permanent error)', () => {
+    assert.equal(
+        isRateLimitLikeError({ status: 408, message: 'Request Timeout' }, 0, { skipPermanentCheck: true }),
+        true
+    );
+});

--- a/src/utils/retry/retryClassifier.ts
+++ b/src/utils/retry/retryClassifier.ts
@@ -2,6 +2,11 @@
 
 const MAX_RETRY_ERROR_DEPTH = 3;
 const RATE_LIMIT_STATUS_CODES = new Set([429, 529]);
+
+// 瞬时超时错误：上游处理超时（如 HuggingFace inference 冷启动/排队超时透传 408），
+// 重试通常能成功。语义上不属于限流，单列清单以便未来独立调整退避策略。
+// 504 由 isServerError() 的 5xx 路径覆盖，此处不重复。
+const TRANSIENT_TIMEOUT_STATUS_CODES = new Set([408]);
 const RATE_LIMIT_ERROR_CODES = new Set([
     '429',
     '529',
@@ -154,6 +159,14 @@ export function isRateLimitLikeError(error: RetryableErrorLike, deep = 0, option
         return true;
     }
 
+    if (TRANSIENT_TIMEOUT_STATUS_CODES.has(error.status as number)) {
+        return true;
+    }
+
+    if (TRANSIENT_TIMEOUT_STATUS_CODES.has(error.statusCode as number)) {
+        return true;
+    }
+
     const code =
         typeof error.code === 'string' || typeof error.code === 'number' ? String(error.code).toLowerCase() : '';
     if (code && RATE_LIMIT_ERROR_CODES.has(code)) {
@@ -169,7 +182,13 @@ export function isRateLimitLikeError(error: RetryableErrorLike, deep = 0, option
     if (message) {
         const normalizedMessage = message.toLowerCase();
 
-        if (normalizedMessage.includes('429') || normalizedMessage.includes('529')) {
+        // 状态码兜底：handler 丢失 status 字段时（如 Sub2API 透传 "Upstream error: 408"），
+        // 从消息文案匹配 HTTP 状态码数字。408 为瞬时超时，429/529 为限流。
+        if (
+            normalizedMessage.includes('408') ||
+            normalizedMessage.includes('429') ||
+            normalizedMessage.includes('529')
+        ) {
             return true;
         }
 


### PR DESCRIPTION
## Problem

当上游 API 返回 HTTP 408 (Request Timeout) 时,GCMP 不会自动重试,直接把错误抛给用户:

```
Sorry, your request failed. Please try again.
Reason: Upstream error: 408
```

408 是**瞬时错误**(上游处理超时),重试通常能成功。不重试会导致:
- 偶发的 408 直接中断用户的对话/补全请求
- 用户需要手动点"重试",体验差
- 在自动化 agent 场景(Copilot Chat 长任务)中,一次 408 就导致整个任务失败

## Root Cause

`src/utils/retry/retryClassifier.ts` 的可重试状态码清单只包含 429 和 529:

```ts
const RATE_LIMIT_STATUS_CODES = new Set([429, 529]);
```

`isRateLimitLikeError()` 用这个清单判断错误是否可重试。408 不在清单里,因此 `executeWithRetry()` 收到 408 后直接退出重试循环。

## Reproduction

- 模型:`hf/zai-org/GLM-5.2-FP8`(通过 Sub2API 网关转发到 HuggingFace Inference Provider)
- 上游 HuggingFace inference 端点偶发返回 408(模型冷启动/排队超时)
- Sub2API 透传 408 状态码给 GCMP
- GCMP 不重试,直接报错

## Solution

采用独立瞬时错误清单(而非混入限流清单),语义清晰,便于未来独立调整退避策略:

```ts
const RATE_LIMIT_STATUS_CODES = new Set([429, 529]);
// 504 由 isServerError() 的 5xx 路径覆盖,此处不重复
const TRANSIENT_TIMEOUT_STATUS_CODES = new Set([408]);
```

在 `isRateLimitLikeError()` 中对 `TRANSIENT_TIMEOUT_STATUS_CODES` 检查 `status`/`statusCode`。

### Message 兜底

issue 实际报错文案为 `Upstream error: 408`(网关透传,status 字段可能丢失)。对等 429/529 已有的 message 数字兜底,增加 `'408'` 匹配:

```ts
if (
    normalizedMessage.includes('408') ||
    normalizedMessage.includes('429') ||
    normalizedMessage.includes('529')
) {
    return true;
}
```

## Design Decisions

### 为什么 504 不加?

经源码核实,`RetryManager.isServerError()` 第 261 行 `code === 502 || code === 503 || code === 504` **已覆盖 504**。issue 中"504 不在判断范围"的描述有误,此处不重复添加。

### 永久错误否决仍然有效

`isRateLimitLikeError()` 开头先执行 `hasPermanentErrorSignal()` 检查。408 即使命中状态码,如果错误对象同时携带永久错误信号(如 `code: 'insufficient_credits'`、上下文超限等),仍会被否决,不会误重试。

### 调用链验证

```
executeModelRequest (genericModelProvider.ts)
  → retryManager.executeWithRetry(operation, shouldRetryRequest, ...)
    → shouldRetryRequest
      ├─ isRateLimitError → isRateLimitLikeError  ← 408 在此命中
      ├─ isServerError                          ← 504 在此命中
      └─ isNetworkError
```

`ZhipuProvider.shouldRetryRequest` override 调用 `super.shouldRetryRequest()`,自动继承 408 重试能力。全项目无其他重试判断函数。

## Verification

- ✅ 单元测试:新增 8 个用例,37/37 全部通过
- ✅ TypeScript 类型检查 (`tsc --noEmit`):无错误
- ✅ esbuild 编译 (`npm run compile`):成功

### 新增测试用例

| 用例 | 覆盖场景 |
|---|---|
| `treats HTTP 408 status as retryable transient timeout` | status 字段 |
| `treats HTTP 408 statusCode as retryable transient timeout` | statusCode 字段 |
| `treats nested 408 status through cause chain as retryable` | 嵌套 cause 链 |
| `permanent error overrides HTTP 408 status` | 永久错误否决 |
| `treats message-only "Upstream error: 408" as retryable` | status 丢失时的 message 兜底 |
| `treats message-only "Request Timeout" without 408 digit as not retryable` | 纯文案无状态码数字不误判 |
| `treats nested message-only 408 through cause chain as retryable` | 嵌套 message 兜底 |
| `skipPermanentCheck does not affect 408` | skipPermanentCheck 选项兼容 |

## Files Changed

- `src/utils/retry/retryClassifier.ts` — 新增 `TRANSIENT_TIMEOUT_STATUS_CODES` 清单、status 检查、message 兜底
- `src/utils/retry/retryClassifier.test.ts` — 新增 8 个测试用例