### PR TITLE
feat(multiDay): 在汇总卡片新增缓存命中率 #374

### DIFF
--- a/src/ui/multiDayView/components/summaryCards.ts
+++ b/src/ui/multiDayView/components/summaryCards.ts
@@ -94,6 +94,14 @@ export function createSummaryCards(data: MultiDayAnalysisResult, options: MultiD
     );
     container.appendChild(card4);
 
+    const card5 = makeCard(
+        t('Cache Hit Rate', '缓存命中率'),
+        `${(data.summary.cacheHitRate * 100).toFixed(1)}%`,
+        `${formatTokens(data.summary.totalCache)} ${t('cache', '缓存')} / ${formatTokens(data.summary.totalInput)} ${t('input', '输入')}`,
+        'cache-hit'
+    );
+    container.appendChild(card5);
+
     return container;
 }
 

--- a/src/ui/multiDayView/style.less
+++ b/src/ui/multiDayView/style.less
@@ -133,6 +133,9 @@ body {
         &.type-cost .card-value {
             color: #e74c3c;
         }
+        &.type-cache-hit .card-value {
+            color: #9b59b6;
+        }
 
         &[data-toggle-cost-currency='true'] {
             cursor: pointer;

--- a/src/usages/multiDay/multiDayAggregator.ts
+++ b/src/usages/multiDay/multiDayAggregator.ts
@@ -298,6 +298,8 @@ export class MultiDayAggregator {
                     share: grandRequests > 0 ? modelRanking[0].totalRequests / grandRequests : 0
                 }
             :   null;
+        // 周期总缓存命中率：总缓存 token / 总输入 token，无输入则 0
+        const summaryCacheHitRate = grandInput > 0 ? grandCache / grandInput : 0;
 
         const trendSeries = this.buildTrendSeries(dates);
 
@@ -323,6 +325,7 @@ export class MultiDayAggregator {
                 dailyAvgCostRmb,
                 topProvider,
                 topModel,
+                cacheHitRate: summaryCacheHitRate,
                 tokensChangePct: null
             },
             providerRanking,
@@ -453,6 +456,7 @@ export class MultiDayAggregator {
                 dailyAvgCostRmb: 0,
                 topProvider: null,
                 topModel: null,
+                cacheHitRate: 0,
                 tokensChangePct: null
             },
             providerRanking: [],

--- a/src/usages/multiDay/types.ts
+++ b/src/usages/multiDay/types.ts
@@ -108,6 +108,8 @@ export interface MultiDayAnalysisResult {
         topProvider: { key: string; name: string; share: number } | null;
         /** 最活跃模型 */
         topModel: { id: string; name: string; share: number } | null;
+        /** 周期内总缓存命中率（cache / input） */
+        cacheHitRate: number;
         /** 环比变化（与上一等长周期对比） */
         tokensChangePct: number | null;
     };


### PR DESCRIPTION
## 背景

[Issue #374](https://github.com/VicBilibily/GCMP/issues/374) 希望在多日消耗分析的汇总区增加「缓存命中率」展示。

## 改动

汇总层计算总缓存命中率（周期内 `totalCache / totalInput`），并在汇总卡片末尾新增第 5 张卡片展示该指标。

- `src/usages/multiDay/types.ts`：summary 新增 `cacheHitRate` 字段
- `src/usages/multiDay/multiDayAggregator.ts`：聚合时计算汇总缓存命中率（含 `emptyResult` 默认值 0）
- `src/ui/multiDayView/components/summaryCards.ts`：新增第 5 张卡片，标题「缓存命中率」、副文案展示「缓存 token / 输入 token」
- `src/ui/multiDayView/style.less`：新增 `type-cache-hit` 卡片颜色（紫色 `#9b59b6`）

## 验证

- `npm run compile:dev` 编译通过，bundle 中确认包含新增字符串
- `npm run lint` 在改动文件上无错误
- `npm run test` 全部 213 个测试通过

Closes #374