### PR TITLE
防止 event:keepalive 报错

### DIFF
--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -537,10 +537,10 @@ export class OpenAIHandler {
                 // 残留 event 行会让 SDK 组合出空 data 事件并在 JSON.parse('') 时抛错
                 // 上游兼容服务可能发送无空格的紧凑格式（如 "event:keepalive"），用正则容忍任意空白。
                 const trimmedEventLine = normalizedLine.trimStart();
-                if (/^event:\s*keepalive\s*$/.test(trimmedEventLine)) {
+                if (/^event:\s*keepalive/.test(trimmedEventLine)) {
                     return '';
                 }
-                if (/^event:\s*codex\.rate_limits\s*$/.test(trimmedEventLine)) {
+                if (/^event:\s*codex\.rate_limits/.test(trimmedEventLine)) {
                     return '';
                 }
                 return normalizedLine;

--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -535,11 +535,12 @@ export class OpenAIHandler {
             if (!normalizedLine.startsWith('data:')) {
                 // 过滤 keepalive 心跳与 codex.rate_limits 的 event 行：后者 data 行会被清空，
                 // 残留 event 行会让 SDK 组合出空 data 事件并在 JSON.parse('') 时抛错
+                // 上游兼容服务可能发送无空格的紧凑格式（如 "event:keepalive"），用正则容忍任意空白。
                 const trimmedEventLine = normalizedLine.trimStart();
-                if (
-                    trimmedEventLine.startsWith('event: keepalive') ||
-                    trimmedEventLine.startsWith('event: codex.rate_limits')
-                ) {
+                if (/^event:\s*keepalive\s*$/.test(trimmedEventLine)) {
+                    return '';
+                }
+                if (/^event:\s*codex\.rate_limits\s*$/.test(trimmedEventLine)) {
                     return '';
                 }
                 return normalizedLine;

--- a/src/handlers/openaiHandler.ts
+++ b/src/handlers/openaiHandler.ts
@@ -537,10 +537,10 @@ export class OpenAIHandler {
                 // 残留 event 行会让 SDK 组合出空 data 事件并在 JSON.parse('') 时抛错
                 // 上游兼容服务可能发送无空格的紧凑格式（如 "event:keepalive"），用正则容忍任意空白。
                 const trimmedEventLine = normalizedLine.trimStart();
-                if (/^event:\s*keepalive/.test(trimmedEventLine)) {
-                    return '';
-                }
-                if (/^event:\s*codex\.rate_limits/.test(trimmedEventLine)) {
+                if (
+                    /^event:\s*keepalive/.test(trimmedEventLine) ||
+                    /^event:\s*codex\.rate_limits/.test(trimmedEventLine)
+                ) {
                     return '';
                 }
                 return normalizedLine;


### PR DESCRIPTION
[error] [Extension Host] Response status: 404, status text: 
[error] [Extension Host] Could not parse message into JSON: 
[error] [Extension Host] From chunk: ["event:keepalive"]
[error] [CHAT] extension request ERRORED in STREAM Unexpected end of JSON input: SyntaxError: Unexpected end of JSON input

我使用 compatible provider 和 oai response 时，经常遇到报错，翻log才发现是这个奇葩原因...